### PR TITLE
Added functionality to extract tokens from exfiltrated Teams DB

### DIFF
--- a/TeamFiltration/TeamFiltration/Modules/Exfiltrate.cs
+++ b/TeamFiltration/TeamFiltration/Modules/Exfiltrate.cs
@@ -218,7 +218,7 @@ namespace TeamFiltration.Modules
                     string token = ExfilFromLocalTeamsDB(filePath);
                     if (!string.IsNullOrEmpty(token))
                     {
-                        await SingleTokenExfilAccountAsync(_globalProperties.OutPutPath, new BearerTokenResp() { access_token = HttpUtility.UrlDecode(token.Split('=')[1].Split('&')[0]) }, exfilOptions, msolHandler);
+                        await SingleTokenExfilAccountAsync(_globalProperties.OutPutPath, new BearerTokenResp() { access_token = HttpUtility.UrlDecode(token).Split('=')[1].Split('&')[0] }, exfilOptions, msolHandler);
                     }
                     else
                     {

--- a/TeamFiltration/TeamFiltration/Program.cs
+++ b/TeamFiltration/TeamFiltration/Program.cs
@@ -27,6 +27,7 @@ namespace TeamFiltration
             Console.WriteLine("         --all                 Exfiltrate information from ALL SSO resources (Graph, OWA, SharePoint, OneDrive, Teams)");
             Console.WriteLine("         --aad                 Exfiltrate information from Graph API (domain users and groups)");
             Console.WriteLine("         --teams               Exfiltrate information from Teams API (files, chatlogs, attachments, contactlist)");
+            Console.WriteLine("         --teams-db            Exfiltrate cookies and authentication tokens from an exfiltrated Teams database");
             Console.WriteLine("         --onedrive            Exfiltrate information from OneDrive/SharePoint API (accessible SharePoint files and the users entire OneDrive directory)");
             Console.WriteLine("         --owa                 Exfiltrate information from the Outlook REST API (The last 2k emails, both sent and received) ");
             Console.WriteLine("               --owa-limit     Set the max amount of emails to exfiltrate, default is 2k.");

--- a/TeamFiltration/TeamFiltration/TeamFiltration.csproj
+++ b/TeamFiltration/TeamFiltration/TeamFiltration.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="PushoverNET" Version="1.0.28" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.116" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
     <PackageReference Include="TimeZoneConverter" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Added functionality that can extract access tokens from an exfiltrated Teams database (by specifying a local path) and then uses that to enumerate further