### PR TITLE
Making HttpClient private and adding exfil logging statements to SharepointHandler

### DIFF
--- a/TeamFiltration/TeamFiltration/Handlers/SharePointHandler.cs
+++ b/TeamFiltration/TeamFiltration/Handlers/SharePointHandler.cs
@@ -18,7 +18,7 @@ namespace TeamFiltration.Handlers
 {
     class SharePointHandler
     {
-        public static HttpClient _sharePointClient;
+        private HttpClient _sharePointClient;
 
         private BearerTokenResp _getBearToken { get; set; }
         private GlobalArgumentsHandler _teamFiltrationConfig { get; set; }
@@ -26,10 +26,11 @@ namespace TeamFiltration.Handlers
         private string _username { get; set; }
 
 
-        public SharePointHandler(BearerTokenResp getBearToken, string username, GlobalArgumentsHandler teamFiltrationConfig, bool debugMode = false)
+        public SharePointHandler(BearerTokenResp getBearToken, string username, GlobalArgumentsHandler teamFiltrationConfig, DatabaseHandler databaseHandler, bool debugMode = false)
         {
             this._getBearToken = getBearToken;
             this._username = username;
+            this._databaseHandler = databaseHandler;
             _teamFiltrationConfig = teamFiltrationConfig;
 
             var proxy = new WebProxy
@@ -77,6 +78,8 @@ namespace TeamFiltration.Handlers
                 {
                     try
                     {
+                        _databaseHandler.WriteLog(new Log("EXFIL", "-->" + file.title));
+
                         //https://XX.sharepoint.com/_api/v2.0/shares/
                         if (file.siteInfo.siteUrl == null)
                         {
@@ -91,8 +94,6 @@ namespace TeamFiltration.Handlers
                     }
                     catch (Exception e)
                     {
-
-                   
                         _databaseHandler.WriteLog(new Log(module, $"Failed to download file {file.title}"));
                     }
                 }

--- a/TeamFiltration/TeamFiltration/Modules/Exfiltrate.cs
+++ b/TeamFiltration/TeamFiltration/Modules/Exfiltrate.cs
@@ -454,8 +454,8 @@ namespace TeamFiltration.Modules
         private static async Task OneDriveExfilAsync(BearerTokenResp companySharePointToken, BearerTokenResp msGraphToken, BearerTokenResp teamsToken, BearerTokenResp personalSharePointToken, string outpath)
         {
             var username = Helpers.Generic.GetUsername(teamsToken.access_token);
-            var sharePointHandler = new SharePointHandler(companySharePointToken, username, _globalProperties);
-            var personalSharePointHandler = new SharePointHandler(personalSharePointToken, username, _globalProperties);
+            var sharePointHandler = new SharePointHandler(companySharePointToken, username, _globalProperties, _databaseHandler);
+            var personalSharePointHandler = new SharePointHandler(personalSharePointToken, username, _globalProperties, _databaseHandler);
             var oneDriveGrapHandler = new OneDriveHandler(msGraphToken, username, _globalProperties, _databaseHandler);
             var teamsHandler = new TeamsHandler(teamsToken, _globalProperties);
 


### PR DESCRIPTION
Was running into a problem where the SharepointHandler failed to download recent files and was causing TeamFiltration to crash. This was happening because the HttpClient variable in SharepointHandler.cs was set to public and was being overwritten since the SharepointHandler is called twice (once for the company sharepoint handler and once for the personal sharepoint handler).

I changed the variable to private and added some basic output that displays the files being exfiltrated similar to the output from the OneDriveHandler.